### PR TITLE
Add Extension Model

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
@@ -1,0 +1,25 @@
+package com.github.vitalsoftware.scalaredox.models
+
+import com.github.vitalsoftware.macros.{json, jsonDefaults}
+import org.joda.time.DateTime
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.util.RobustPrimitives
+
+@json case class ExtensionFacilityAddress(line: String, city: String, state: String, postalCode: String)
+
+@json case class DeviceIdExtension(url: String, string: String)
+
+@json case class OrderingFacilityNameExtension(url: String, string: String)
+
+@json case class OrderingFacilityAddressExtension(url: String, address: ExtensionFacilityAddress)
+
+@json case class OrderedDateTimeExtension(url: String, dateTime: DateTime)
+
+@json case class Extension(
+  `device-id`: Option[DeviceIdExtension] = None,
+  `ordering-facility-name`: Option[OrderingFacilityNameExtension] = None,
+  `ordering-facility-address`: Option[OrderingFacilityAddressExtension] = None,
+  `ordered-date-time`: Option[OrderedDateTimeExtension] = None
+)
+
+object Extension extends RobustPrimitives


### PR DESCRIPTION
Add Extension Model

## Purpose
Need to support using Redox extensions

## Approach
This is incomplete and I likely need to think about better ways to model
possible extensions but it works for now.

This model is used to add additional information that Redox needs but
doesn't fit into their normal data models. The `Extension` types i added
here are specifically for ELR reporting.