### PR TITLE
Move implicits to top of function

### DIFF
--- a/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/RedoxTest.scala
@@ -15,11 +15,11 @@ import scala.concurrent.duration._
  * Created by apatzer on 3/23/17.
  */
 trait RedoxTest {
-  val conf = ClientConfig(ConfigFactory.load("resources/reference.conf"))
-  val httpClient = StandaloneAhcWSClient()
   implicit val system = ActorSystem("redox-test")
   implicit val materializer = ActorMaterializer()(system)
 
+  val conf = ClientConfig(ConfigFactory.load("resources/reference.conf"))
+  val httpClient = StandaloneAhcWSClient()
   val tokenManager = new RedoxTokenManager(httpClient, conf.baseRestUri)
   val client = new RedoxClient(conf, httpClient, tokenManager)
   val timeout: FiniteDuration = 20.seconds

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
@@ -16,6 +16,6 @@ class UploadTest extends Specification with RedoxTest {
       val maybe = handleResponse(fut)
       maybe must beSome
       maybe.get.URI must contain("https://blob.redoxengine.com")
-    }.pendingUntilFixed
+    }
   }
 }


### PR DESCRIPTION
## Purpose
At this location my compiler is not happy. Says it can't find them for
the preceding function calls.