### PR TITLE
Fixing the type for Meta.Extensions

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -68,7 +68,7 @@ object NumericIdentifier extends RobustPrimitives
   FacilityCode: Option[String] = None,
   IsIncomplete: Option[Boolean] = None,
   CanceledEvent: Option[RedoxEventTypes.Value] = None,
-  Extensions: Option[Seq[Extension]] = None,
+  Extensions: Option[Extension] = None,
 )
 
 object Meta extends RobustPrimitives

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.3.0"
+version in ThisBuild := "8.3.1"


### PR DESCRIPTION
`Meta.Extensions` should be type `Option[Extension]` and not `Option[Seq[Extension]]`.