### PR TITLE
Set `Content-Length` to `-1L` for `UploadTest`

### DIFF
--- a/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/UploadTest.scala
@@ -12,7 +12,7 @@ class UploadTest extends Specification with RedoxTest {
       val file = Files.createTempFile("test-file", ".txt")
       java.nio.file.Files.newOutputStream(file).write("This is a test".getBytes)
 
-      val fut = client.upload(file.toFile)
+      val fut = client.upload(file = file.toFile, contentLength = -1L)
       val maybe = handleResponse(fut)
       maybe must beSome
       maybe.get.URI must contain("https://blob.redoxengine.com")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "8.3.1"
+version in ThisBuild := "8.3.2"


### PR DESCRIPTION
Historically, the lib had a default content-length of 2mb and we used
that for the `UploadTest`. That doesn't seem to work anymore. Redox has
stopped accepting requests where the `Content-Length` does not
accurately reflect the file being uploaded. Updating the `UploadTest` to
pass in a content length of `-1L` seems to fix the test. I think it has to
do with the tmp file stream created for the test.

This goes back to some investigation that was done [historically](https://github.com/mdcollab/scala-redox/blob/d3b2c82de5ba7553a3514b5edab2699d34898c10/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala#L94-L97).
Setting the `Content-Length` switches the `Transfer-Encoding` to
`chunked`. This seems to resolve the issue with the test.