### PR TITLE
changed empty response body trying to return EmptyResponse to RedoxErrorResponse

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
@@ -47,7 +47,7 @@ abstract class RedoxClientComponents(
 
         // Not failure status but response body is empty
         case r if r.body.isEmpty =>
-          Left(RedoxErrorResponse.simple("Response body is empty with status code: " + r.status))
+          Left(RedoxErrorResponse.simple(s"Response body is empty with status code: ${r.status}"))
 
         // Success status
         case r =>

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
@@ -45,22 +45,22 @@ abstract class RedoxClientComponents(
             case Failure(e) => Left(RedoxErrorResponse.simple(r.statusText, r.body))
           }
 
+        // Not failure status but response body is empty
+        case r if r.body.isEmpty =>
+          Left(RedoxErrorResponse.simple("Response body is empty with status code: " + r.status))
+
         // Success status
         case r =>
-          if (r.body.isEmpty) {
-            Left(RedoxErrorResponse.simple("JSON body is empty"))
-          } else {
-            val json = reducer(r.body[JsValue])
+          val json = reducer(r.body[JsValue])
 
-            Json
-              .fromJson(json)
-              .fold(
-                // Json to Scala objects failed...force into RedoxError format
-                invalid = err => Left(RedoxErrorResponse.fromJsError(JsError(err))),
-                // All good
-                valid = t => Right(t)
-              )
-          }
+          Json
+            .fromJson(json)
+            .fold(
+              // Json to Scala objects failed...force into RedoxError format
+              invalid = err => Left(RedoxErrorResponse.fromJsError(JsError(err))),
+              // All good
+              valid = t => Right(t)
+            )
       }
       .map { response =>
         RedoxResponse[T](response)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClientComponents.scala
@@ -48,7 +48,7 @@ abstract class RedoxClientComponents(
         // Success status
         case r =>
           if (r.body.isEmpty) {
-            Right(EmptyResponse.asInstanceOf[T])
+            Left(RedoxErrorResponse.simple("JSON body is empty"))
           } else {
             val json = reducer(r.body[JsValue])
 


### PR DESCRIPTION
## Purpose
When the redox response has empty body, a class cast exception occurs
https://sentry.io/organizations/carbon/issues/2542268945/?project=233765&referrer=slack

## Approach
An empty JSON body is interpreted as unusual behaviour. Rather than treating it as success, it is considered as failure

#### Open Questions and Pre-Merge TODOs
- [x] Is this approach accepted team-wise? 
- [ ] If not, what should be the wanted behaviour?
- [ ] How should empty response bodies be handled?
- [ ] If we want to return EmptyResponse, should it extend MetaResponse or should there be a new "EmptyMetaResponse"?

## Learning
Checked Response classes and their behaviours. Problem arised when MetaResponse was added later on, after EmptyResponse. These 2 classes were not related to each other any way but EmptyResponse was tried to  cast to MetaResponse but no meta field was tried to pass.