### PR TITLE
add altcodes and email address to models

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Common.scala
@@ -37,6 +37,12 @@ trait DateRange {
 
 object Address extends RobustPrimitives
 
+@jsonDefaults case class EmailAddress(
+  Address: Option[String] = None,
+)
+
+object EmailAddress extends RobustPrimitives
+
 /**
  * Location of provider or care given.
  *

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Observation.scala
@@ -47,6 +47,7 @@ object ProcedureObservation extends RobustPrimitives
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
+  AltCodes: Option[Seq[BasicCode]] = None,
   Status: Option[String] = None,
   Interpretation: Option[String] = None, // Used by Result
   DateTime: DateTime,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -78,7 +78,7 @@ object SexType extends Enumeration {
   Sex: SexType.Value = SexType.Unknown,
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
-  EmailAddresses: Seq[String] = Seq.empty,
+  EmailAddresses: Seq[EmailAddress] = Seq.empty,
   Language: Option[Language] = None,
   Citizenship: Seq[String] = Seq.empty, // TODO ISO 3166
   Race: Option[RaceType.Value] = None,
@@ -98,7 +98,7 @@ object Demographics extends RobustPrimitives
   LastName: Option[String] = None,
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
-  EmailAddresses: Seq[String] = Seq.empty,
+  EmailAddresses: Seq[EmailAddress] = Seq.empty,
   RelationToPatient: Option[String] = None,
   Roles: Seq[String] = Seq.empty
 ) extends WithContactDetails

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Provider.scala
@@ -43,7 +43,7 @@ trait ProviderLike {
 
 trait WithAddress { def Address: Option[Address] }
 trait WithPhoneNumber { def PhoneNumber: Option[PhoneNumber] }
-trait WithEmails { def EmailAddresses: Seq[String] }
+trait WithEmails { def EmailAddresses: Seq[EmailAddress] }
 trait WithContactDetails extends WithAddress with WithPhoneNumber with WithEmails
 
 @jsonDefaults case class BasicPerson(
@@ -51,7 +51,7 @@ trait WithContactDetails extends WithAddress with WithPhoneNumber with WithEmail
   LastName: Option[String] = None,
   Address: Option[Address] = None,
   PhoneNumber: Option[PhoneNumber] = None,
-  EmailAddresses: Seq[String] = Seq.empty,
+  EmailAddresses: Seq[EmailAddress] = Seq.empty,
   Credentials: Option[String] = None
 ) extends WithContactDetails
 

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -107,7 +107,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
         header.Patient.Identifiers must not be empty
         header.Patient.Demographics must beSome
       }.get
-    }.pendingUntilFixed
+    }
 
     "return a VisitQueryResponse" in {
       val json =
@@ -198,7 +198,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
         //val results = visitQueryResponse.Results
         //results.size must be_>(0)
       }.get
-    }.pendingUntilFixed
+    }
   }
 
   "post ClinicalSummary" should {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -308,7 +308,11 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |					"Home": "+18088675301",
           |					"Mobile": null
           |				},
-          |				"EmailAddresses": [],
+          |				"EmailAddresses": [
+          |               {
+          |                 "Address": "12313124@fake.com"
+          |               }
+          |             ],
           |				"Race": "Asian",
           |				"IsHispanic": null,
           |				"Religion": null,

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/FlowSheetTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/FlowSheetTest.scala
@@ -98,7 +98,9 @@ class FlowSheetTest extends Specification with RedoxTest {
           |            },
           |            "RelationToPatient": "Mother",
           |            "EmailAddresses": [
-          |               "barb.bixby@test.net"
+          |               {
+          |                 "Address": "barb.bixby@test.net"
+          |               }
           |            ],
           |            "Roles": [
           |               "Emergency Contact"

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ResultsTest.scala
@@ -1,7 +1,14 @@
 package com.github.vitalsoftware.scalaredox
 
 import com.github.vitalsoftware.scalaredox.client.EmptyResponse
-import com.github.vitalsoftware.scalaredox.models.{AbnormalFlagTypes, OrderResultsStatusTypes, Result, ResultStatusTypes, ResultsMessage, ResultsStatusTypes}
+import com.github.vitalsoftware.scalaredox.models.{
+  AbnormalFlagTypes,
+  OrderResultsStatusTypes,
+  Result,
+  ResultStatusTypes,
+  ResultsMessage,
+  ResultsStatusTypes
+}
 import org.specs2.mutable.Specification
 
 /**
@@ -101,7 +108,9 @@ class ResultsTest extends Specification with RedoxTest {
           |            },
           |            "RelationToPatient": "Mother",
           |            "EmailAddresses": [
-          |               "barb.bixby@test.net"
+          |               {
+          |                 "Address": "barb.bixby@test.net"
+          |               }
           |            ],
           |            "Roles": [
           |               "Emergency Contact"


### PR DESCRIPTION
### What
Add missing altcodes and email address to models.

### Why
Altcodes and Email address is contained in Patient Push JSON requests coming from Redox. They needed to be
added so that Redox requests can pass validation correctly.