### PR TITLE
Update Receive controller to optionally take max content length

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveController.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/receiver/ReceiveController.scala
@@ -26,12 +26,15 @@ trait ReceiveController extends BaseController {
    *
    * @see http://developer.redoxengine.com/getting-started/create-a-destination/
    */
-  protected def validatedAction(verifiedAction: RedoxRequest => Future[Result]): Action[JsValue] =
-    Action(parse.json).async({ request: Request[JsValue] =>
+  protected def validatedAction(
+    verifiedAction: RedoxRequest => Future[Result],
+    maxContentLength: Long = 1024 * 100, // Default is 100KB
+  ): Action[JsValue] =
+    Action(parse.json(maxLength = maxContentLength)).async({ request: Request[JsValue] =>
       RedoxRequest(request).token match {
         case Some(token) if token == verificationToken =>
           verifiedAction(RedoxRequest(request))
-        case Some(token) =>
+        case Some(_) =>
           // The verification token is incorrect
           logger.error(s"Redox webhook had an incorrect token from ${RedoxRequest(request)}")
           Future.successful(Forbidden(s"Validation failed."))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.4"
+version in ThisBuild := "10.0.5"


### PR DESCRIPTION
## Purpose
New CCDA Import endpoint uses `ReceiveController`. We may get big CCDA files (more than 5MB) that we need to process. We may need to change max content length to process these, so added optional field to change max content length. Default is still 100KB like play api.
