### PR TITLE
VisitPush event type for Clinical Summary + some extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Package repository hosting is graciously provided by  [Cloudsmith](https://cloud
 
 Publishing is currently done via SBT. Artefacts are stored on Cloudsmith.io. To publish, make sure you have a Cloudsmith account and have publish access to the [Carbon repository](https://cloudsmith.io/orgs/carbon-health/).
 
-Create/Edit the `~/.sbt/credentials` file:
+Create/Edit the `~/.sbt/.credentials` file:
 ```
 realm=Cloudsmith API
 host=maven.cloudsmith.io
@@ -126,6 +126,8 @@ password=<cloudsmith.io user password>
 ```
 
 You will need to increment the version appropriately in `version.sbt`, as duplicate versions are not allowed.
+
+You can publish a test version by declaring a non-semver-compliant version number in `version.sbt`, like `10.0.8-RC1`. This published version will not be picked up automatically by users of the `scala-redox` SDK, but can be included to test new changes prior to making an actual release. We should remove the test packages from cloudsmith when testing is complete.
 
 Running `sbt publish` will build and push the new version to cloudsmith.
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val playVersion = "2.7.3"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % playJsonVersion,
+  "ai.x" %% "play-json-extensions" % "0.42.0",
   "com.typesafe.play" %% "play-logback" % playJsonVersion,
   "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
   "com.typesafe.play" %% "play-ahc-ws" % playVersion,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
@@ -5,11 +5,7 @@ import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.util.RobustPrimitives
 
-@jsonDefaults case class CodeSetForExtension(
-  Code: Option[String] = None,
-  Display: Option[String]
-)
-object CodesetForExtension extends RobustPrimitives
+@json case class ExtensionCodeset( code: Option[String] = None, display: Option[String])
 
 @json case class ExtensionFacilityAddress(line: String, city: String, state: String, postalCode: String)
 
@@ -28,8 +24,8 @@ object CodesetForExtension extends RobustPrimitives
 // Carequality extensions present in Meta object for queries
 @json case class SenderOrganizationIdExtension(url: String, string: String) // Carequality Organization OID
 @json case class UserIdExtension(url: String, string: String) // Querying user ID from your system
-@json case class UserRoleExtension(url: String, coding: CodesetForExtension ) // SNOMED CT code https://www.hl7.org/fhir/valueset-practitioner-role.html
-@json case class PurposeOfUseExtension(url: String, string: String) // Always use "treatment"
+@json case class UserRoleExtension(url: String, coding: ExtensionCodeset ) // SNOMED CT code https://www.hl7.org/fhir/valueset-practitioner-role.html
+@json case class PurposeOfUseExtension(url: String, coding: ExtensionCodeset) // Always use { code: "TREATMENT", display: "Treatment" }
 
 @json case class Extension(
   `device-id`: Option[DeviceIdExtension] = None,
@@ -40,7 +36,7 @@ object CodesetForExtension extends RobustPrimitives
   `sender-organization-id`: Option[SenderOrganizationIdExtension] = None,
   `user-id`: Option[UserIdExtension] = None,
   `user-role`: Option[UserRoleExtension] = None,
-  `organization-id`: Option[SenderOrganizationIdExtension] = None,
+  `purpose-of-use`: Option[PurposeOfUseExtension] = None,
 )
 
 object Extension extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
@@ -5,6 +5,12 @@ import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.util.RobustPrimitives
 
+@jsonDefaults case class CodeSetForExtension(
+  Code: Option[String] = None,
+  Display: Option[String]
+)
+object CodesetForExtension extends RobustPrimitives
+
 @json case class ExtensionFacilityAddress(line: String, city: String, state: String, postalCode: String)
 
 @json case class DeviceIdExtension(url: String, string: String)
@@ -19,12 +25,22 @@ import com.github.vitalsoftware.util.RobustPrimitives
 
 @json case class DocumentExtension(url: String, string: String)
 
+// Carequality extensions present in Meta object for queries
+@json case class SenderOrganizationIdExtension(url: String, string: String) // Carequality Organization OID
+@json case class UserIdExtension(url: String, string: String) // Querying user ID from your system
+@json case class UserRoleExtension(url: String, coding: CodesetForExtension ) // SNOMED CT code https://www.hl7.org/fhir/valueset-practitioner-role.html
+@json case class PurposeOfUseExtension(url: String, string: String) // Always use "treatment"
+
 @json case class Extension(
   `device-id`: Option[DeviceIdExtension] = None,
   `ordering-facility-name`: Option[OrderingFacilityNameExtension] = None,
   `ordering-facility-address`: Option[OrderingFacilityAddressExtension] = None,
   `ordered-date-time`: Option[OrderedDateTimeExtension] = None,
   `organization-id`: Option[OrganizationIdExtension] = None,
+  `sender-organization-id`: Option[SenderOrganizationIdExtension] = None,
+  `user-id`: Option[UserIdExtension] = None,
+  `user-role`: Option[UserRoleExtension] = None,
+  `organization-id`: Option[SenderOrganizationIdExtension] = None,
 )
 
 object Extension extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Extension.scala
@@ -1,6 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models
 
-import com.github.vitalsoftware.macros.{json, jsonDefaults}
+import com.github.vitalsoftware.macros.{ json, jsonDefaults }
 import org.joda.time.DateTime
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.util.RobustPrimitives
@@ -16,6 +16,8 @@ import com.github.vitalsoftware.util.RobustPrimitives
 @json case class OrderedDateTimeExtension(url: String, dateTime: DateTime)
 
 @json case class OrganizationIdExtension(url: String, string: String)
+
+@json case class DocumentExtension(url: String, string: String)
 
 @json case class Extension(
   `device-id`: Option[DeviceIdExtension] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -62,6 +62,23 @@ object TimePeriod extends RobustPrimitives
 object MedicationTaken extends RobustPrimitives
 
 /**
+  * @param ReasonNotGiven 
+  *
+  */
+@jsonDefaults case class MedicationGiven (
+  Dose: Option[Dose] = None,
+  Rate: Option[Dose] = None,
+  Route: Option[BasicCode] = None,
+  StartDate: DateTime,
+  EndDate: Option[DateTime] = None,
+  Frequency: Option[TimePeriod] = None,
+  Product: BasicCode = BasicCode(),
+  ReasonNotGiven: Option[String],
+)
+
+object MedicationGiven extends RobustPrimitives
+
+/**
  *
  * @param Code Code for the pharmacy.
  * @param Codeset Code set used to identify the pharmacy.

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Medication.scala
@@ -62,7 +62,6 @@ object TimePeriod extends RobustPrimitives
 object MedicationTaken extends RobustPrimitives
 
 /**
-  * @param ReasonNotGiven 
   *
   */
 @jsonDefaults case class MedicationGiven (
@@ -74,7 +73,7 @@ object MedicationTaken extends RobustPrimitives
   Frequency: Option[TimePeriod] = None,
   Product: BasicCode = BasicCode(),
   ReasonNotGiven: Option[String],
-)
+) extends Medication
 
 object MedicationGiven extends RobustPrimitives
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Document.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Document.scala
@@ -1,7 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{ BasicCode, HasVisitInfo, Provider, VisitInfo }
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, DocumentExtension, HasVisitInfo, Provider, VisitInfo }
 import com.github.vitalsoftware.util.RobustPrimitives
 import org.joda.time.DateTime
 import play.api.libs.json.JodaWrites._
@@ -28,6 +28,7 @@ import play.api.libs.json.JodaReads._
   Type: Option[String] = None,
   TypeCode: Option[BasicCode] = None,
   Visit: Option[VisitInfo] = None,
+  Extensions: Option[DocumentExtension] = None,
 ) extends HasVisitInfo
 
 object Document extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
@@ -1,18 +1,10 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary
 
-import com.github.vitalsoftware.macros.{json, jsonDefaults}
+import ai.x.play.json.Encoders.encoder
+import ai.x.play.json.Jsonx
 import com.github.vitalsoftware.scalaredox.models.{AdvanceDirective, Allergy, ChartResult, Encounter, FamilyHistory, Immunization, Insurance, MedicalEquipment, MedicationGiven, MedicationTaken, Meta, PlanOfCare, Problem, Procedures, SocialHistory, VitalSigns}
-import com.github.vitalsoftware.util.RobustPrimitives
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
-import play.api.libs.json.Format.GenericFormat
-import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
-import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
-import play.api.libs.json.{Json, OFormat, Reads, Writes, __}
 
 import scala.collection.Seq
-
-// Have to provide a formatter since VisitPush has more than 22 params -> no unapply method can be generated
 
 /**
  * https://developer.redoxengine.com/data-models/ClinicalSummary.html#VisitPush
@@ -44,24 +36,17 @@ import scala.collection.Seq
  * @param SubjectiveText Free text description of the patient's condition as reported by the patient + documented by clinician (plain text only, no markup)
  * @param VitalSigns An array of groups of vital signs. Each element represents one time period in which vitals were recorded.
  */
-// Leaving some of these out for now since:
-// * JSON serialization relies on the case class' "unapply" function
-// * case classes can contain more than 22 constructor args, but tuples are capped at length 22
-// * case class with more than 22 constructor args can't generate an "unapply" function
-// * VisitPush case class _would_ have 24 constructor args
-// * => VisitPush would not be JSON serializable
-// Removing things that are included in PatientAdmin^PatientUpdate for now
-@jsonDefaults case class VisitPush(
+case class VisitPush(
   Meta: Meta,
   Header: Header,
   AdvanceDirectives: Seq[AdvanceDirective] = Seq.empty,
-//  Allergies: Seq[Allergy] = Seq.empty,
+  Allergies: Seq[Allergy] = Seq.empty,
   Encounters: Seq[Encounter] = Seq.empty,
   FamilyHistory: Seq[FamilyHistory] = Seq.empty,
   Immunizations: Seq[Immunization] = Seq.empty,
   InstructionsText: Option[String] = None,
   InterventionsText: Option[String] = None,
-//  Insurances: Seq[Insurance] = Seq.empty,
+  Insurances: Seq[Insurance] = Seq.empty,
   MedicalEquipment: Seq[MedicalEquipment] = Seq.empty,
   Medications: Seq[MedicationTaken] = Seq.empty,
   MedicationsAdministered: Seq[MedicationGiven] = Seq.empty,
@@ -78,4 +63,6 @@ import scala.collection.Seq
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
 
-object VisitPush extends RobustPrimitives
+object VisitPush {
+  implicit val format = Jsonx.formatCaseClassUseDefaults[VisitPush]
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
@@ -24,6 +24,8 @@ import play.api.libs.json.JodaReads._
 import scala.collection.Seq
 
 /**
+ * https://developer.redoxengine.com/data-models/ClinicalSummary.html#VisitPush
+ * 
  * @param Meta Request/response clinical summary header meta-data
  * @param Header Message header
  * @param AdvanceDirectives advance directives
@@ -31,20 +33,27 @@ import scala.collection.Seq
  * @param Encounters A code describing the type of encounter (office visit, hospital, etc). CPT-4
  * @param FamilyHistory Each element of the FamilyHistory is one person in the patient's family.
  * @param Immunizations List of patient immunization codes
+ * @param InstructionsText Free text patient education/instructions (plain text only, no markup)
+ * @param InterventionsText Free text about interventions given during visit (procedural, education, application of assistive equipment, etc.) (plain text only, no markup)
  * @param Insurances List of insurance coverages for the patient
  * @param MedicalEquipment A list of medical equipment that the patient uses (cane, pacemakers, etc.)
  * @param Medications Array of medications
+ * @param MedicationsAdministered Array of medications administered during this visit
  * @param PlanOfCare Free text form of the plan of care summary
  * @param Problems An array of all of patient relevant problems, current and historical.
  * @param Procedures A general grouper for all things that CDA considers procedures, grouped into three kinds.
  *                   -Observations - procedures which result in new information about a patient.
  *                   -Procedures - procedures whose immediate and primary outcome is the alteration of the physical condition of the patient.
  *                   -Services (Sometimes called Acts) - procedures which cannot be classified as an observation or a procedure, such as a dressing change, feeding, or teaching.
+ * @param ReasonForReferralText
+ * @param ReasonForVisitText
  * @param Results Array of test results for the patient. This can include laboratory results, imaging results, and procedure Results[].
+ * @param ReviewOfSystemsText Free text about symptoms and wellbeing of the patient (plain text only, no markup)
  * @param SocialHistory Generic observations about the patient's social history
+ * @param SubjectiveText Free text description of the patient's condition as reported by the patient + documented by clinician (plain text only, no markup)
  * @param VitalSigns An array of groups of vital signs. Each element represents one time period in which vitals were recorded.
  */
-@jsonDefaults case class PatientPush(
+@jsonDefaults case class VisitPush(
   Meta: Meta,
   Header: Header,
   AdvanceDirectives: Seq[AdvanceDirective] = Seq.empty,
@@ -52,14 +61,22 @@ import scala.collection.Seq
   Encounters: Seq[Encounter] = Seq.empty,
   FamilyHistory: Seq[FamilyHistory] = Seq.empty,
   Immunizations: Seq[Immunization] = Seq.empty,
+  InstructionsText: Option[String] = None,
+  InterventionsText: Option[String] = None,
   Insurances: Seq[Insurance] = Seq.empty,
   MedicalEquipment: Seq[MedicalEquipment] = Seq.empty,
   Medications: Seq[MedicationTaken] = Seq.empty,
+  MedicationsAdministered: Seq[MedicationGiven] = Seq.empty,
+  ObjectiveText: Option[String] = None,
   PlanOfCare: Option[PlanOfCare] = None,
   Problems: Seq[Problem] = Seq.empty,
   Procedures: Option[Procedures] = None,
+  ReasonForReferralText: Option[String] = None,
+  ReasonForVisitText: Option[String] = None,
   Results: Seq[ChartResult] = Seq.empty,
+  ReviewOfSystemsText: Option[String] = None,
   SocialHistory: Option[SocialHistory] = None,
+  SubjectiveText: Option[String] = None,
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
@@ -1,27 +1,18 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary
 
-import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{
-  AdvanceDirective,
-  Allergy,
-  ChartResult,
-  Encounter,
-  FamilyHistory,
-  Immunization,
-  Insurance,
-  MedicalEquipment,
-  MedicationTaken,
-  Meta,
-  PlanOfCare,
-  Problem,
-  Procedures,
-  SocialHistory,
-  VitalSigns
-}
+import com.github.vitalsoftware.macros.{json, jsonDefaults}
+import com.github.vitalsoftware.scalaredox.models.{AdvanceDirective, Allergy, ChartResult, Encounter, FamilyHistory, Immunization, Insurance, MedicalEquipment, MedicationGiven, MedicationTaken, Meta, PlanOfCare, Problem, Procedures, SocialHistory, VitalSigns}
 import com.github.vitalsoftware.util.RobustPrimitives
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.JodaWrites._
 import play.api.libs.json.JodaReads._
+import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites
+import play.api.libs.json.{Json, OFormat, Reads, Writes, __}
+
 import scala.collection.Seq
+
+// Have to provide a formatter since VisitPush has more than 22 params -> no unapply method can be generated
 
 /**
  * https://developer.redoxengine.com/data-models/ClinicalSummary.html#VisitPush
@@ -53,17 +44,24 @@ import scala.collection.Seq
  * @param SubjectiveText Free text description of the patient's condition as reported by the patient + documented by clinician (plain text only, no markup)
  * @param VitalSigns An array of groups of vital signs. Each element represents one time period in which vitals were recorded.
  */
+// Leaving some of these out for now since:
+// * JSON serialization relies on the case class' "unapply" function
+// * case classes can contain more than 22 constructor args, but tuples are capped at length 22
+// * case class with more than 22 constructor args can't generate an "unapply" function
+// * VisitPush case class _would_ have 24 constructor args
+// * => VisitPush would not be JSON serializable
+// Removing things that are included in PatientAdmin^PatientUpdate for now
 @jsonDefaults case class VisitPush(
   Meta: Meta,
   Header: Header,
   AdvanceDirectives: Seq[AdvanceDirective] = Seq.empty,
-  Allergies: Seq[Allergy] = Seq.empty,
+//  Allergies: Seq[Allergy] = Seq.empty,
   Encounters: Seq[Encounter] = Seq.empty,
   FamilyHistory: Seq[FamilyHistory] = Seq.empty,
   Immunizations: Seq[Immunization] = Seq.empty,
   InstructionsText: Option[String] = None,
   InterventionsText: Option[String] = None,
-  Insurances: Seq[Insurance] = Seq.empty,
+//  Insurances: Seq[Insurance] = Seq.empty,
   MedicalEquipment: Seq[MedicalEquipment] = Seq.empty,
   Medications: Seq[MedicationTaken] = Seq.empty,
   MedicationsAdministered: Seq[MedicationGiven] = Seq.empty,
@@ -80,4 +78,4 @@ import scala.collection.Seq
   VitalSigns: Seq[VitalSigns] = Seq.empty
 ) extends ClinicalSummaryLike
 
-object PatientPush extends RobustPrimitives
+object VisitPush extends RobustPrimitives

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -281,6 +281,10 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |			"Title": "Community Health and Hospitals: Health Summary",
           |			"DateTime": "2012-09-12T00:00:00.000Z",
           |			"Type": "Summarization of Episode Note"
+          |         "Extensions": {
+          |            "url": "https://api.redoxengine.com/extensions/file-contents",
+          |            "string": "filename.xml"
+          |         }
           |		},
           |		"Patient": {
           |			"Identifiers": [
@@ -1117,6 +1121,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
       h.Document.Author must beSome
       h.Document.Author.flatMap(_.Address) must beSome
       h.Document.Visit must beSome
+      h.Document.Extensions must beSome
       h.Patient.Identifiers must not be empty
       h.Patient.Demographics must beSome
       h.Patient.Demographics.flatMap(_.Address) must beSome

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -1194,18 +1194,21 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
       patientPush.Immunizations must not be empty
       patientPush.MedicalEquipment must not be empty
       patientPush.Medications must not be empty
-      patientPush.Medications.head.Status must be(Some("active"))
-      patientPush.Medications.head.NumberOfRefillsRemaining must be(Some(2))
-      patientPush.Medications.head.Extensions.get.Indication.get.coding.system must be("2.16.840.1.113883.6.90")
-      patientPush.Medications.head.Extensions.get.Indication.get.coding.code must be("J18.1")
-      patientPush.Medications.head.Extensions.get.Indication.get.coding.display must be("Lobar pneumonia")
-      patientPush.Medications.head.Extensions.get.`author-id`.get.string must be("7236481726")
-      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.use must be("usual")
-      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.text must be("Billy Bob Smith")
-      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.`given` must be(Seq("Billy", "Bob"))
-      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.family must be("Smith")
-      patientPush.Medications(1).Status must be(Some("completed"))
-      patientPush.Medications(1).NumberOfRefillsRemaining must be(Some(1))
+      patientPush.Medications.head.Status must beSome("active")
+      patientPush.Medications.head.NumberOfRefillsRemaining must beSome(2)
+      patientPush.Medications.head.Extensions.get.Indication.get.coding.system must be equalTo ("2.16.840.1.113883.6.90")
+      patientPush.Medications.head.Extensions.get.Indication.get.coding.code must be equalTo ("J18.1")
+      patientPush.Medications.head.Extensions.get.Indication.get.coding.display must be equalTo ("Lobar pneumonia")
+      patientPush.Medications.head.Extensions.get.`author-id`.get.string must be equalTo ("7236481726")
+      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.use must be equalTo ("usual")
+      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.text must be equalTo ("Billy Bob Smith")
+      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.`given` must be equalTo (Seq(
+        "Billy",
+        "Bob"
+      ))
+      patientPush.Medications.head.Extensions.get.`author-name`.get.humanName.family must be equalTo ("Smith")
+      patientPush.Medications(1).Status must beSome("completed")
+      patientPush.Medications(1).NumberOfRefillsRemaining must beSome(1)
       patientPush.Medications(1).Extensions must beSome
       patientPush.PlanOfCare must beSome
       patientPush.PlanOfCare.get.Encounters must not be empty

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -706,38 +706,38 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |			}
           |		}
           |	],
-          |	"Medications": [
-          |		{
-          |			"Prescription": false,
-          |			"FreeTextSig": null,
-          |			"Dose": {
-          |				"Quantity": "4",
-          |				"Units": "mg"
-          |			},
-          |			"Rate": {
-          |				"Quantity": null,
-          |				"Units": null
-          |			},
-          |			"Route": {
-          |				"Code": "C38288",
-          |				"CodeSystem": "2.16.840.1.113883.3.26.1.1",
-          |				"CodeSystemName": "NCI Thesaurus",
-          |				"Name": "Oral"
-          |			},
+          |    "Medications": [
+          |        {
+          |            "Prescription": false,
+          |            "FreeTextSig": null,
+          |            "Dose": {
+          |                "Quantity": "4",
+          |                "Units": "mg"
+          |            },
+          |            "Rate": {
+          |                "Quantity": null,
+          |                "Units": null
+          |            },
+          |            "Route": {
+          |                "Code": "C38288",
+          |                "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |                "CodeSystemName": "NCI Thesaurus",
+          |                "Name": "Oral"
+          |            },
           |         "Status": "active",
-          |			"StartDate": "2013-11-11T05:00:00.000Z",
-          |			"EndDate": null,
-          |			"Frequency": {
-          |				"Period": "8",
-          |				"Unit": "h"
-          |			},
+          |            "StartDate": "2013-11-11T05:00:00.000Z",
+          |            "EndDate": null,
+          |            "Frequency": {
+          |                "Period": "8",
+          |                "Unit": "h"
+          |            },
           |         "NumberOfRefillsRemaining": 2,
-          |			"Product": {
-          |				"Code": "104894",
-          |				"CodeSystem": "2.16.840.1.113883.6.88",
-          |				"CodeSystemName": "RxNorm",
-          |				"Name": "Ondansetron 4 Mg Po Tbdp"
-          |			},
+          |            "Product": {
+          |                "Code": "104894",
+          |                "CodeSystem": "2.16.840.1.113883.6.88",
+          |                "CodeSystemName": "RxNorm",
+          |                "Name": "Ondansetron 4 Mg Po Tbdp"
+          |            },
           |         "Extensions": {
           |             "Indication": {
           |                 "url": "https://api.redoxengine.com/extensions/indication",
@@ -763,39 +763,39 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |                     ]
           |                 }
           |             }
-          |		    }
+          |            }
           |     },
-          |		{
-          |			"Prescription": false,
-          |			"FreeTextSig": null,
-          |			"Dose": {
-          |				"Quantity": "0.09",
-          |				"Units": "mg/actuat"
-          |			},
-          |			"Rate": {
-          |				"Quantity": "90",
-          |				"Units": "ml/min"
-          |			},
-          |			"Route": {
-          |				"Code": "C38216",
-          |				"CodeSystem": "2.16.840.1.113883.3.26.1.1",
-          |				"CodeSystemName": "NCI Thesaurus",
-          |				"Name": "RESPIRATORY (INHALATION)"
-          |			},
+          |        {
+          |            "Prescription": false,
+          |            "FreeTextSig": null,
+          |            "Dose": {
+          |                "Quantity": "0.09",
+          |                "Units": "mg/actuat"
+          |            },
+          |            "Rate": {
+          |                "Quantity": "90",
+          |                "Units": "ml/min"
+          |            },
+          |            "Route": {
+          |                "Code": "C38216",
+          |                "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |                "CodeSystemName": "NCI Thesaurus",
+          |                "Name": "RESPIRATORY (INHALATION)"
+          |            },
           |         "Status": "completed",
-          |			"StartDate": "2012-08-06T04:00:00.000Z",
-          |			"EndDate": "2012-08-13T04:00:00.000Z",
-          |			"Frequency": {
-          |				"Period": "12",
-          |				"Unit": "h"
-          |			},
+          |            "StartDate": "2012-08-06T04:00:00.000Z",
+          |            "EndDate": "2012-08-13T04:00:00.000Z",
+          |            "Frequency": {
+          |                "Period": "12",
+          |                "Unit": "h"
+          |            },
           |         "NumberOfRefillsRemaining": 1,
-          |			"Product": {
-          |				"Code": "573621",
-          |				"CodeSystem": "2.16.840.1.113883.6.88",
-          |				"CodeSystemName": "RxNorm",
-          |				"Name": "Albuterol 0.09 MG/ACTUAT inhalant solution"
-          |			},
+          |            "Product": {
+          |                "Code": "573621",
+          |                "CodeSystem": "2.16.840.1.113883.6.88",
+          |                "CodeSystemName": "RxNorm",
+          |                "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution"
+          |            },
           |        "Extensions": {
           |         "Indication": {
           |             "url": "https://api.redoxengine.com/extensions/indication",
@@ -816,16 +816,14 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |                 "text": "Billy Bob Smith",
           |                 "family": "Smith",
           |                 "given": [
-          |                     "Billy",
-          |                     "Bob"
-          |                 ],
-          |                 "family": "Smith"
+          |                    "Billy",
+          |                    "Bob"
+          |                 ]
           |             }
           |         }
-          |      }
-          |		}
+          |        }
           |  }
-          |	],
+          |    ],
           |	"PlanOfCare": {
           |		"Orders": [
           |			{

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -816,11 +816,12 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |                 "text": "Billy Bob Smith",
           |                 "given": [
           |                     "Billy",
-          |                     "Bob",
-          |                 ]
-          |                 "family": "Smith",
+          |                     "Bob"
+          |                 ],
+          |                 "family": "Smith"
           |             }
           |         }
+          |      }
           |		}
           |	],
           |	"PlanOfCare": {

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -227,7 +227,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |		},
           |		"Destinations": [
           |			{
-          |				"ID": "ef9e7448-7f65-4432-aa96-059647e9b358",
+          |				"ID": "ef9e7448-7f65-4432-aa96-059647e9b357",
           |				"Name": "Clinical Summary Push Endpoint"
           |			}
           |		],
@@ -280,7 +280,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |			"Locale": "US",
           |			"Title": "Community Health and Hospitals: Health Summary",
           |			"DateTime": "2012-09-12T00:00:00.000Z",
-          |			"Type": "Summarization of Episode Note"
+          |			"Type": "Summarization of Episode Note",
           |         "Extensions": {
           |            "url": "https://api.redoxengine.com/extensions/file-contents",
           |            "string": "filename.xml"
@@ -1165,6 +1165,6 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
       val fut = client.post[PatientPush, EmptyResponse](patientPush)
       val maybe = handleResponse(fut)
       maybe must beSome
-    }.pendingUntilFixed
+    }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.9"
+version in ThisBuild := "10.0.10"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.6"
+version in ThisBuild := "10.0.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.7"
+version in ThisBuild := "10.0.8-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.2.0"
+version in ThisBuild := "10.1.0-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.1.0-RC1"
+version in ThisBuild := "10.2.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.9"
+version in ThisBuild := "10.2.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.0.8-RC1"
+version in ThisBuild := "10.0.9"


### PR DESCRIPTION
In order to use Redox as a query responder on the Carequality network, we need to push Clinical Summary data to their Data-on-Demand product via the `PatientPush` and `VisitPush` event types:

https://developer.redoxengine.com/data-models/ClinicalSummary.html#PatientPush
https://developer.redoxengine.com/data-models/ClinicalSummary.html#VisitPush

The `PatientPush` event type is already present in this SDK but `VisitPush` needs to be added.

Additionally, in order to use Redox to query for patients/organizations/documents on the Carequality network, we need a few extensions for the Meta object in the query datamodels.