### PR TITLE
Create separate inbound PatientPush

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -7,7 +7,8 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{ FileIO, Source }
 import com.github.vitalsoftware.scalaredox._
 import com.github.vitalsoftware.scalaredox.models.{ RedoxEventTypes, Upload }
-import com.github.vitalsoftware.scalaredox.models.clinicalsummary.{ PatientPush, PatientQueryResponse }
+import com.github.vitalsoftware.scalaredox.models.clinicalsummary.PatientQueryResponse
+import com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound.PatientPush
 import com.github.vitalsoftware.util.JsonImplicits.JsValueExtensions
 import com.github.vitalsoftware.util.RobustParsing
 import com.typesafe.config.Config

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -23,7 +23,7 @@ object RedoxEventTypes extends Enumeration {
   // format: off
   val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge,
       GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery,
-      PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace,
+      PatientQueryResponse, PatientPush, PatientInboundPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace,
       Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse,
       VisitPush, VisitUpdate, Administration, Invalid = Value
   // format: on

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -23,7 +23,7 @@ object RedoxEventTypes extends Enumeration {
   // format: off
   val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge,
       GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery,
-      PatientQueryResponse, PatientPush, PatientInboundPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace,
+      PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace,
       Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse,
       VisitPush, VisitUpdate, Administration, Invalid = Value
   // format: on

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Problem.scala
@@ -22,8 +22,9 @@ import com.github.vitalsoftware.util.RobustPrimitives
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
   Category: BasicCode = BasicCode(),
-  //HealthStatus: Option[BasicCode] = None, // TODO Seems to come back as HealthStatus: { null, null, null, null } which violates the constraints of BasicCode
-  Status: Option[BasicCode] = None
+  HealthStatus: BasicCode = BasicCode(),
+  Status: Option[BasicCode] = None,
+  Comment: Option[String] = None,
 ) extends Code
 
 object Problem extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/AdvanceDirective.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/AdvanceDirective.scala
@@ -1,0 +1,39 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, BasicPerson, Code }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Advance directive documents that the healthcare organization has on file for the patient.
+ *
+ * @param Type The value of the advance directive (such as 'Do not resuscitate'). SNOMED CT
+ * @param StartDate Effective start date of the advance directive. ISO 8601 Format
+ * @param EndDate Effective end date of the advance directive. ISO 8601 Format
+ * @param ExternalReference A link to a location where the document can be accessed.
+ * @param VerifiedBy A collection of people who verified the advance directive with the patient
+ * @param Custodians People legally responsible for the advance directive document.
+ */
+@jsonDefaults case class AdvanceDirective(
+  Type: BasicCode = BasicCode(),
+  Code: Option[String] = None, // Todo Question: Seems to duplicate 'Type' field
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime],
+  ExternalReference: Option[String],
+  VerifiedBy: Seq[BasicPerson] = Seq.empty, // Todo missing VerifiedBy.DateTime
+  Custodians: Seq[BasicPerson] = Seq.empty
+) extends Code
+
+object AdvanceDirective extends RobustPrimitives
+
+@jsonDefaults case class AdvanceDirectiveMessage(
+  AdvanceDirectivesText: Option[String] = None,
+  advanceDirectives: Seq[AdvanceDirective] = Seq.empty
+)
+
+object AdvanceDirectiveMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Common.scala
@@ -1,0 +1,31 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ Address, BasicCode }
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ * Patient identifier
+ *
+ * @param ID The actual identifier for the patient.
+ * @param IDType An ID type associated with identifier (Medical Record Number, etc.)
+ */
+@jsonDefaults case class Identifier(
+  ID: Option[String] = None,
+  IDType: Option[String] = None
+)
+
+/**
+ * Location of provider or care given.
+ *
+ * @see https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.6.259
+ * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
+ */
+@jsonDefaults case class Location(
+  Address: Option[Address] = None,
+  Type: BasicCode = BasicCode(),
+  Name: Option[String] = None
+)
+
+object Location extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
@@ -1,0 +1,43 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Identifier, Location, Provider }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ *
+ * @param Type A code describing the type of encounter (office visit, hospital, etc). CPT-4
+ * @param DateTime When the encounter took place, or alternatively when the encounter began if Encounters[].EndDateTime is present. ISO 8601 Format
+ * @param EndDateTime When the encounter was completed, if available. ISO 8601 Format
+ * @param Providers Providers seen
+ * @param Locations The type of location where the patient was seen (Clinic, Urgent Care, Hostpital).
+ * @param Diagnosis List of Diagnoses associated with the visit. SNOMED CT
+ * @param ReasonForVisit The reason for the visit (usually this is what the patient reports). SNOMED CT
+ */
+@jsonDefaults case class Encounter(
+  Identifiers: Seq[Identifier] = Seq.empty,
+  Type: BasicCode = BasicCode(),
+  DateTime: Option[DateTime] = None,
+  EndDateTime: Option[DateTime] = None,
+  Providers: Seq[Provider] = Seq.empty,
+  Locations: Seq[Location] = Seq.empty,
+  Diagnosis: Seq[BasicCode] = Seq.empty,
+  ReasonForVisit: Seq[BasicCode] = Seq.empty
+)
+
+object Encounter extends RobustPrimitives
+
+/**
+ * This section lists the patient's past encounters at the health system and associated diagnoses.
+ *
+ * @param EncountersText Free text form of the encounters summary
+ * @param Encounters Patient encounters
+ */
+@jsonDefaults case class EncountersMessage(
+  EncountersText: Option[String],
+  Encounters: Seq[Encounter] = Seq.empty
+)
+
+object EncountersMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
@@ -2,9 +2,34 @@ package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
-import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Identifier, Location, Provider }
+import com.github.vitalsoftware.scalaredox.models.{ Address, BasicCode, Provider }
 import com.github.vitalsoftware.util.RobustPrimitives
 import org.joda.time.DateTime
+
+/**
+ * Patient identifier
+ *
+ * @param ID The actual identifier for the patient.
+ * @param IDType An ID type associated with identifier (Medical Record Number, etc.)
+ */
+@jsonDefaults case class Identifier(
+  ID: Option[String] = None,
+  IDType: Option[String] = None
+)
+
+/**
+ * Location of provider or care given.
+ *
+ * @see https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.6.259
+ * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
+ */
+@jsonDefaults case class Location(
+  Address: Option[Address] = None,
+  Type: BasicCode = BasicCode(),
+  Name: Option[String] = None
+)
+
+object Location extends RobustPrimitives
 
 /**
  *
@@ -28,16 +53,3 @@ import org.joda.time.DateTime
 )
 
 object Encounter extends RobustPrimitives
-
-/**
- * This section lists the patient's past encounters at the health system and associated diagnoses.
- *
- * @param EncountersText Free text form of the encounters summary
- * @param Encounters Patient encounters
- */
-@jsonDefaults case class EncountersMessage(
-  EncountersText: Option[String],
-  Encounters: Seq[Encounter] = Seq.empty
-)
-
-object EncountersMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
@@ -7,31 +7,6 @@ import com.github.vitalsoftware.util.RobustPrimitives
 import org.joda.time.DateTime
 
 /**
- * Patient identifier
- *
- * @param ID The actual identifier for the patient.
- * @param IDType An ID type associated with identifier (Medical Record Number, etc.)
- */
-@jsonDefaults case class Identifier(
-  ID: Option[String] = None,
-  IDType: Option[String] = None
-)
-
-/**
- * Location of provider or care given.
- *
- * @see https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.113883.6.259
- * Note: Seems duplicative of CareLocation, but described using the generic 'Code' object
- */
-@jsonDefaults case class Location(
-  Address: Option[Address] = None,
-  Type: BasicCode = BasicCode(),
-  Name: Option[String] = None
-)
-
-object Location extends RobustPrimitives
-
-/**
  *
  * @param Type A code describing the type of encounter (office visit, hospital, etc). CPT-4
  * @param DateTime When the encounter took place, or alternatively when the encounter began if Encounters[].EndDateTime is present. ISO 8601 Format

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/FamilyHistory.scala
@@ -1,0 +1,13 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ FamilyHistoryProblem, Relation }
+import com.github.vitalsoftware.util.RobustPrimitives
+
+@jsonDefaults case class FamilyHistory(
+  Relation: Option[Relation] = None,
+  Problems: Seq[FamilyHistoryProblem] = Seq.empty
+)
+
+object FamilyHistory extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Immunization.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Immunization.scala
@@ -1,0 +1,24 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Dose, ImmunizationProduct }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Immunization given.
+ *
+ * @param DateTime When the immunization was given. ISO 8601 Format
+ * @param Route The way in which the immunization was delivered (Intramuscular, Oral, etc.). [Medication Route FDA Value Set](http://www.fda.gov/ForIndustry/DataStandards/StructuredProductLabeling%20/ucm162034.htm)
+ * @param Product The vaccination that was given.
+ * @param Dose Dosage
+ */
+@jsonDefaults case class Immunization(
+  DateTime: Option[DateTime] = None,
+  Route: Option[BasicCode] = None,
+  Product: Option[ImmunizationProduct] = None,
+  Dose: Option[Dose] = None
+)
+
+object Immunization extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/MedicalEquipment.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/MedicalEquipment.scala
@@ -1,0 +1,24 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.BasicCode
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Piece of medical equipment.
+ *
+ * @param Status The current status of the equipment (active, completed, etc.)
+ * @param StartDate When the equipment was first put into use. ISO 8601 Format
+ * @param Quantity The number of products used
+ * @param Product A code representing the actual product. SNOMED CT
+ */
+@jsonDefaults case class MedicalEquipment(
+  Status: Option[String] = None,
+  StartDate: Option[DateTime] = None,
+  Quantity: Option[String] = None, // Todo Int?
+  Product: BasicCode = BasicCode()
+)
+
+object MedicalEquipment extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Medication.scala
@@ -1,0 +1,29 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Dose, MedicationExtension, TimePeriod }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * @param Prescription Whether the medication is a prescription. For a prescription: true. For a patient reported med, or a med administered by a provider: false
+ * @param FreeTextSig Free text instructions for the medication. Typically instructing patient on the proper means and timing for the use of the medication
+ */
+@jsonDefaults case class MedicationTaken(
+  Prescription: Option[Boolean] = None,
+  FreeTextSig: Option[String] = None,
+  Dose: Option[Dose] = None,
+  Rate: Option[Dose] = None,
+  Route: Option[BasicCode] = None,
+  Status: Option[String] = None,
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime] = None,
+  Frequency: Option[TimePeriod] = None,
+  NumberOfRefillsRemaining: Option[Double] = None,
+  IsPRN: Option[Boolean] = None,
+  Product: BasicCode = BasicCode(),
+  Extensions: Option[MedicationExtension] = None,
+)
+
+object MedicationTaken extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
@@ -1,7 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{ Allergy, Insurance, Meta, PlanOfCare, Problem }
+import com.github.vitalsoftware.scalaredox.models.{ Allergy, Insurance, Meta, Problem }
 import com.github.vitalsoftware.scalaredox.models.clinicalsummary.{ ClinicalSummaryLike, Header }
 import com.github.vitalsoftware.util.RobustPrimitives
 import play.api.libs.json.JodaWrites._

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
@@ -1,0 +1,52 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.scalaredox.models.{ Allergy, Insurance, Meta, PlanOfCare, Problem }
+import com.github.vitalsoftware.scalaredox.models.clinicalsummary.{ ClinicalSummaryLike, Header }
+import com.github.vitalsoftware.util.RobustPrimitives
+import play.api.libs.json.JodaWrites._
+import play.api.libs.json.JodaReads._
+
+import scala.collection.Seq
+
+/**
+ * @param Meta Request/response clinical summary header meta-data
+ * @param Header Message header
+ * @param AdvanceDirectives advance directives
+ * @param Allergies A code for the type of allergy intolerance this is (food, drug, etc.). [Allergy/Adverse Event Type Value Set](http://phinvads.cdc.gov/vads/ViewValueSet.action?id=7AFDBFB5-A277-DE11-9B52-0015173D1785)
+ * @param Encounters A code describing the type of encounter (office visit, hospital, etc). CPT-4
+ * @param FamilyHistory Each element of the FamilyHistory is one person in the patient's family.
+ * @param Immunizations List of patient immunization codes
+ * @param Insurances List of insurance coverages for the patient
+ * @param MedicalEquipment A list of medical equipment that the patient uses (cane, pacemakers, etc.)
+ * @param Medications Array of medications
+ * @param PlanOfCare Free text form of the plan of care summary
+ * @param Problems An array of all of patient relevant problems, current and historical.
+ * @param Procedures A general grouper for all things that CDA considers procedures, grouped into three kinds.
+ *                   -Observations - procedures which result in new information about a patient.
+ *                   -Procedures - procedures whose immediate and primary outcome is the alteration of the physical condition of the patient.
+ *                   -Services (Sometimes called Acts) - procedures which cannot be classified as an observation or a procedure, such as a dressing change, feeding, or teaching.
+ * @param Results Array of test results for the patient. This can include laboratory results, imaging results, and procedure Results[].
+ * @param SocialHistory Generic observations about the patient's social history
+ * @param VitalSigns An array of groups of vital signs. Each element represents one time period in which vitals were recorded.
+ */
+@jsonDefaults case class PatientPush(
+  Meta: Meta,
+  Header: Header,
+  AdvanceDirectives: Seq[AdvanceDirective] = Seq.empty,
+  Allergies: Seq[Allergy] = Seq.empty,
+  Encounters: Seq[Encounter] = Seq.empty,
+  FamilyHistory: Seq[FamilyHistory] = Seq.empty,
+  Immunizations: Seq[Immunization] = Seq.empty,
+  Insurances: Seq[Insurance] = Seq.empty,
+  MedicalEquipment: Seq[MedicalEquipment] = Seq.empty,
+  Medications: Seq[MedicationTaken] = Seq.empty,
+  PlanOfCare: Option[PlanOfCare] = None,
+  Problems: Seq[Problem] = Seq.empty,
+  Procedures: Option[Procedures] = None,
+  Results: Seq[ChartResult] = Seq.empty,
+  SocialHistory: Option[SocialHistory] = None,
+  VitalSigns: Seq[VitalSigns] = Seq.empty
+) extends ClinicalSummaryLike
+
+object PatientPush extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
@@ -1,6 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, CodeWithStatus, Dose, TimePeriod }
 import com.github.vitalsoftware.util.RobustPrimitives
 import org.joda.time.DateTime

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
@@ -1,0 +1,43 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, CodeWithStatus, Dose, TimePeriod }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Medication to be given.
+ */
+@jsonDefaults case class MedicationPlan(
+  Status: Option[String] = None,
+  Dose: Option[Dose] = None,
+  Rate: Option[Dose] = None,
+  Route: Option[BasicCode] = None,
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime] = None,
+  Frequency: Option[TimePeriod] = None,
+  Product: BasicCode = BasicCode()
+)
+
+object MedicationPlan extends RobustPrimitives
+
+/**
+ * @see PlanOfCareMessage
+ *
+ * @param Orders Future lab tests or other diagnostic procedure.
+ * @param Procedures These are procedures that alter the state of the body, such as an appendectomy or hip replacement. SNOMED CT
+ * @param Encounters The encounter type that is planned. SNOMED CT
+ * @param MedicationAdministration Medications planned.
+ * @param Supplies Future supplies that a patient may be given, including implants. SNOMED CT
+ * @param Services These are procedures that are service-oriented in nature, such as a dressing change, or feeding a patient. SNOMED CT
+ */
+@jsonDefaults case class PlanOfCare(
+  Orders: Seq[CodeWithStatus] = Seq.empty,
+  Procedures: Seq[CodeWithStatus] = Seq.empty,
+  Encounters: Seq[CodeWithStatus] = Seq.empty,
+  MedicationAdministration: Seq[MedicationPlan] = Seq.empty,
+  Supplies: Seq[CodeWithStatus] = Seq.empty,
+  Services: Seq[CodeWithStatus] = Seq.empty
+)
+
+object PlanOfCare extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Procedures.scala
@@ -1,0 +1,37 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, CodeWithStatus }
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Procedure observation
+ *
+ * Used within ClinicalSummary's Procedures.Observations[]. Has no units.
+ */
+@jsonDefaults case class ProcedureObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  DateTime: Option[DateTime] = None,
+  Status: Option[String] = None,
+  TargetSite: Option[BasicCode] = None,
+)
+
+object ProcedureObservation extends RobustPrimitives
+
+/**
+ * @param Observations These are procedures that are more observational in nature, such as an EEG or EKG.
+ * @param Procedures The procedure that was performed. SNOMED CT
+ * @param Services These are procedures that are service-oriented in nature, such as a dressing change, or feeding a patient.
+ */
+@jsonDefaults case class Procedures(
+  Observations: Seq[ProcedureObservation] = Seq.empty,
+  Procedures: Seq[CodeWithStatus] = Seq.empty,
+  Services: Seq[CodeWithStatus] = Seq.empty
+)
+
+object Procedures extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
@@ -1,0 +1,57 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.{
+  BasicCode,
+  ChartResultProducer,
+  Code,
+  ReferenceRange,
+  Status,
+  ValueTypes
+}
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Result observation
+ *
+ * Used within ClincialSummary's Results[].Observations[]
+ */
+@jsonDefaults case class ResultObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  AltCodes: Option[Seq[BasicCode]] = None,
+  Status: Option[String] = None,
+  Interpretation: Option[String] = None, // Used by Result
+  DateTime: Option[DateTime] = None,
+  CodedValue: Option[BasicCode] = None, // Used by Result
+  Value: Option[String] = None,
+  ValueType: Option[ValueTypes.Value] = None,
+  Units: Option[String] = None,
+  ReferenceRange: Option[ReferenceRange] = None,
+)
+
+object ResultObservation extends RobustPrimitives
+
+/**
+ * Result from laboratories, imaging procedures, and other procedures.
+ *
+ * @param Code The test performed and resulted. LOINC for Lab - SNOMED CT otherwise
+ * @param Status The status of the test (In Progress, Final)
+ * @param Observations A list of corresponding observations for the test (result components)
+ */
+@jsonDefaults case class ChartResult(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Status: Option[String] = None,
+  Producer: Option[ChartResultProducer] = None,
+  Observations: Seq[ResultObservation] = Seq.empty
+) extends Code
+    with Status
+
+object ChartResult extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/SocialHistory.scala
@@ -1,0 +1,62 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.scalaredox.models.BasicCode
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * @param Code A code for the observation (exercise, alcohol intake, etc.) . SNOMED CT
+ * @param Value The coded observed value for the code
+ * @param ValueText The observed value for the code
+ */
+@jsonDefaults case class SocialHistoryObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime] = None,
+  Value: Option[BasicCode] = None,
+  ValueText: Option[String] = None
+)
+
+object SocialHistoryObservation extends RobustPrimitives
+
+/**
+ * @param StartDate When the pregnancy started. ISO 8601 Format
+ * @param EndDate When the pregnancy ended. ISO 8601 Format
+ * @param EstimatedDelivery Estimate delivery date if pregnancy is still active.
+ */
+@jsonDefaults case class Pregnancy(
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime] = None,
+  EstimatedDelivery: Option[String] = None
+)
+
+object Pregnancy extends RobustPrimitives
+
+/**
+ * @param Code A code indicating the status (current smoker, never smoker, snuff user, etc.). Contains all values descending from the SNOMED CT® 365980008 tobacco use and exposure - finding hierarchy
+ * @param StartDate Start date of status
+ * @param EndDate Date status ended. If this is null, the status is current.
+ */
+@jsonDefaults case class TobaccoUse(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  StartDate: Option[DateTime] = None,
+  EndDate: Option[DateTime] = None
+)
+
+object TobaccoUse extends RobustPrimitives
+
+@jsonDefaults case class SocialHistory(
+  Observations: Seq[SocialHistoryObservation] = Seq.empty,
+  Pregnancy: Seq[Pregnancy] = Seq.empty,
+  TobaccoUse: Seq[TobaccoUse] = Seq.empty
+)
+
+object SocialHistory extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/VitalSigns.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/VitalSigns.scala
@@ -1,0 +1,37 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+
+/**
+ * Vital sign observation
+ *
+ * Used within ClinicalSummary's VitalSigns[].Observations[]
+ */
+@jsonDefaults case class VitalSignObservation(
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Status: Option[String] = None,
+  Interpretation: Option[String] = None,
+  DateTime: Option[DateTime] = None,
+  Value: Option[String] = None,
+  Units: Option[String] = None,
+)
+
+object VitalSignObservation extends RobustPrimitives
+
+/**
+ * @param DateTime The date and time of the reading. ISO 8601 Format
+ * @param Observations The type of vital sign being read (height, weight, blood pressure, etc.).
+ *                     Subset of LOINC codes (HITSP Vital Sign Result Type).
+ */
+@jsonDefaults case class VitalSigns(
+  DateTime: Option[DateTime] = None,
+  Observations: Seq[VitalSignObservation] = Seq.empty
+)
+
+object VitalSigns extends RobustPrimitives

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -1239,4 +1239,1017 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
       maybe must beSome
     }
   }
+
+  "post inbound PatientPush" should {
+    "return OK" in {
+      val json =
+        """
+          |{
+          |	"Meta": {
+          |		"DataModel": "Clinical Summary",
+          |		"EventType": "PatientPush",
+          |		"EventDateTime": "2017-03-14T19:35:06.047Z",
+          |		"Test": true,
+          |		"Source": {
+          |			"ID": "7ce6f387-c33c-417d-8682-81e83628cbd9",
+          |			"Name": "Redox Dev Tools"
+          |		},
+          |		"Destinations": [
+          |			{
+          |				"ID": "ef9e7448-7f65-4432-aa96-059647e9b357",
+          |				"Name": "Clinical Summary Push Endpoint"
+          |			}
+          |		],
+          |		"Message": {
+          |			"ID": 5565
+          |		},
+          |		"Transmission": {
+          |			"ID": 12414
+          |		}
+          |	},
+          |	"Header": {
+          |		"Document": {
+          |			"ID": "75cb4ad4-e5f9-4cd3-8750-eb5050521e0d",
+          |			"Author": {
+          |				"ID": "4356789876",
+          |				"IDType": "NPI",
+          |				"Type": null,
+          |				"FirstName": "Pat",
+          |				"LastName": "Granite",
+          |				"Credentials": [
+          |					"MD"
+          |				],
+          |				"Address": {
+          |					"StreetAddress": "123 Main St.",
+          |					"City": "Madison",
+          |					"State": "WI",
+          |					"ZIP": "53703",
+          |					"County": "Dane",
+          |					"Country": "USA"
+          |				},
+          |				"Location": {
+          |					"Type": null,
+          |					"Facility": null,
+          |					"Department": null
+          |				},
+          |				"PhoneNumber": {
+          |					"Office": "+16085551234"
+          |				}
+          |			},
+          |			"Visit": {
+          |				"Location": {
+          |					"Type": "Inpatient",
+          |					"Facility": "RES General Hospital",
+          |					"Department": "3N"
+          |				},
+          |				"StartDateTime": "2017-03-15T00:35:26.713Z",
+          |				"Reason": "Annual Physical",
+          |				"EndDateTime": "2017-03-15T00:35:26.713Z"
+          |			},
+          |			"Locale": "US",
+          |			"Title": "Community Health and Hospitals: Health Summary",
+          |			"DateTime": "2012-09-12T00:00:00.000Z",
+          |			"Type": "Summarization of Episode Note",
+          |         "Extensions": {
+          |            "url": "https://api.redoxengine.com/extensions/file-contents",
+          |            "string": "filename.xml"
+          |         }
+          |		},
+          |		"Patient": {
+          |			"Identifiers": [
+          |				{
+          |					"ID": "0000000001",
+          |					"IDType": "MR",
+          |					"Type": null
+          |				},
+          |				{
+          |					"ID": "e167267c-16c9-4fe3-96ae-9cff5703e90a",
+          |					"IDType": "EHRID",
+          |					"Type": null
+          |				},
+          |				{
+          |					"ID": "a1d4ee8aba494ca^^^&1.3.6.1.4.1.21367.2005.13.20.1000&ISO",
+          |					"IDType": "NIST",
+          |					"Type": null
+          |				}
+          |			],
+          |			"Demographics": {
+          |				"FirstName": "Timothy",
+          |				"LastName": "Bixby",
+          |				"DOB": "2008-01-06",
+          |				"SSN": "101-01-0001",
+          |				"Sex": "Male",
+          |				"Address": {
+          |					"StreetAddress": "4762 Hickory Street",
+          |					"City": "Monroe",
+          |					"State": "WI",
+          |					"County": "Green",
+          |					"Country": "US",
+          |					"ZIP": "53566"
+          |				},
+          |				"PhoneNumber": {
+          |					"Home": "+18088675301",
+          |					"Mobile": null
+          |				},
+          |				"EmailAddresses": [
+          |               {
+          |                 "Address": "12313124@fake.com"
+          |               }
+          |             ],
+          |				"Race": "Asian",
+          |				"IsHispanic": null,
+          |				"Religion": null,
+          |				"MaritalStatus": "Single"
+          |			}
+          |		}
+          |	},
+          |	"AdvanceDirectives": [
+          |		{
+          |			"Type": {
+          |				"Code": "304251008",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Resuscitation"
+          |			},
+          |			"Code": "304253006",
+          |			"CodeSystem": "2.16.840.1.113883.6.96",
+          |			"CodeSystemName": "SNOMED CT",
+          |			"Name": "Do not resuscitate",
+          |			"StartDate": "2011-02-13T05:00:00.000Z",
+          |			"EndDate": null,
+          |			"ExternalReference": "AdvanceDirective.b50b7910-7ffb-4f4c-bbe4-177ed68cbbf3.pdf",
+          |			"VerifiedBy": [
+          |				{
+          |					"FirstName": "Robert",
+          |					"LastName": "Dolin",
+          |					"Credentials": "Dr.",
+          |					"DateTime": null
+          |				}
+          |			],
+          |			"Custodians": [
+          |				{
+          |					"FirstName": "Robert",
+          |					"LastName": "Dolin",
+          |					"Credentials": "Dr.",
+          |					"Address": {
+          |						"StreetAddress": "21 North Ave.",
+          |						"City": "Burlington",
+          |						"State": "MA",
+          |						"Country": "USA",
+          |						"ZIP": "02368"
+          |					}
+          |				}
+          |			]
+          |		}
+          |	],
+          |	"Allergies": [
+          |		{
+          |			"Type": {
+          |				"Code": "419511003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Propensity to adverse reaction to drug"
+          |			},
+          |			"Substance": {
+          |				"Code": "7982",
+          |				"CodeSystem": "2.16.840.1.113883.6.88",
+          |				"CodeSystemName": "RxNorm",
+          |				"Name": "Penicillin G benzathine"
+          |			},
+          |			"Reaction": [
+          |				{
+          |					"Code": "28926001",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Rash",
+          |					"Text": null
+          |				},
+          |				{
+          |					"Code": "247472004",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Hives",
+          |					"Text": null
+          |				}
+          |			],
+          |			"Severity": {
+          |				"Code": "371924009",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Moderate to severe"
+          |			},
+          |			"Status": {
+          |				"Code": "73425007",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Inactive"
+          |			},
+          |			"StartDate": null,
+          |			"EndDate": null
+          |		},
+          |		{
+          |			"Type": {
+          |				"Code": "419511003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Propensity to adverse reaction to drug"
+          |			},
+          |			"Substance": {
+          |				"Code": "2670",
+          |				"CodeSystem": "2.16.840.1.113883.6.88",
+          |				"CodeSystemName": "RxNorm",
+          |				"Name": "Codeine"
+          |			},
+          |			"Reaction": [
+          |				{
+          |					"Code": "267036007",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Shortness of Breath",
+          |					"Text": null
+          |				}
+          |			],
+          |			"Severity": {
+          |				"Code": "6736007",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Moderate"
+          |			},
+          |			"Status": {
+          |				"Code": "55561003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Active"
+          |			},
+          |			"StartDate": null,
+          |			"EndDate": null
+          |		},
+          |		{
+          |			"Type": {
+          |				"Code": "419511003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Propensity to adverse reaction to drug"
+          |			},
+          |			"Substance": {
+          |				"Code": "1191",
+          |				"CodeSystem": "2.16.840.1.113883.6.88",
+          |				"CodeSystemName": "RxNorm",
+          |				"Name": "Aspirin"
+          |			},
+          |			"Reaction": [
+          |				{
+          |					"Code": "247472004",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Hives",
+          |					"Text": null
+          |				}
+          |			],
+          |			"Severity": {
+          |				"Code": "371923003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Mild to moderate"
+          |			},
+          |			"Status": {
+          |				"Code": "55561003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Active"
+          |			},
+          |			"StartDate": null,
+          |			"EndDate": null
+          |		}
+          |	],
+          |	"Encounters": [
+          |		{
+          |  "Identifiers": [
+          |        {
+          |           "ID": "2376492",
+          |           "IDType": "URMC Epic CSN"
+          |        },
+          |        {
+          |           "ID": "8237334",
+          |           "IDType": "1.35.829.5.238422.9.10"
+          |        }
+          |     ],
+          |			"Type": {
+          |				"Code": "99222",
+          |				"CodeSystem": "2.16.840.1.113883.6.12",
+          |				"CodeSystemName": "CPT",
+          |				"Name": "InPatient Admission"
+          |			},
+          |			"DateTime": "2012-08-06T04:00:00.000Z",
+          |			"EndDateTime": null,
+          |			"Providers": [
+          |				{
+          |					"ID": null,
+          |					"IDType": null,
+          |					"FirstName": null,
+          |					"LastName": null,
+          |					"Credentials": [],
+          |					"Address": {
+          |						"StreetAddress": null,
+          |						"City": null,
+          |						"State": null,
+          |						"ZIP": null,
+          |						"County": null,
+          |						"Country": null
+          |					},
+          |					"Location": {
+          |						"Type": null,
+          |						"Facility": null,
+          |						"Department": null
+          |					},
+          |					"PhoneNumber": {
+          |						"Office": null
+          |					},
+          |					"Role": {
+          |						"Code": "59058001",
+          |						"CodeSystem": "2.16.840.1.113883.6.96",
+          |						"CodeSystemName": "SNOMED CT",
+          |						"Name": "General Physician"
+          |					}
+          |				}
+          |			],
+          |			"Locations": [
+          |				{
+          |					"Address": {
+          |						"StreetAddress": "1002 Healthcare Dr",
+          |						"City": "Portland",
+          |						"State": "OR",
+          |						"Country": "US",
+          |						"ZIP": "97266"
+          |					},
+          |					"Type": {
+          |						"Code": "1160-1",
+          |						"CodeSystem": "2.16.840.1.113883.6.259",
+          |						"CodeSystemName": "HealthcareServiceLocation",
+          |						"Name": "Urgent Care Center"
+          |					},
+          |					"Name": "Community Health and Hospitals"
+          |				}
+          |			],
+          |			"Diagnosis": [
+          |				{
+          |					"Code": "233604007",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Pneumonia"
+          |				}
+          |			],
+          |			"ReasonForVisit": [
+          |				{
+          |					"Code": "233604007",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Pneumonia"
+          |				}
+          |			]
+          |		}
+          |	],
+          |	"FamilyHistory": [
+          |		{
+          |			"Relation": {
+          |				"Code": "FTH",
+          |				"CodeSystem": "2.16.840.1.113883.5.111",
+          |				"CodeSystemName": "HL7 FamilyMember",
+          |				"Name": "Father",
+          |				"Demographics": {
+          |					"Sex": "Male",
+          |					"DOB": "1912-01-01"
+          |				},
+          |				"IsDeceased": true
+          |			},
+          |			"Problems": [
+          |				{
+          |					"Code": "22298006",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Myocardial infarction",
+          |					"Type": {
+          |						"Code": "55561003",
+          |						"CodeSystem": "2.16.840.1.113883.6.96",
+          |						"CodeSystemName": "SNOMED CT",
+          |						"Name": "Active"
+          |					},
+          |					"DateTime": null,
+          |					"AgeAtOnset": "57",
+          |					"IsCauseOfDeath": null
+          |				},
+          |				{
+          |					"Code": "46635009",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED CT",
+          |					"Name": "Diabetes mellitus type 1",
+          |					"Type": {
+          |						"Code": "7087005",
+          |						"CodeSystem": "2.16.840.1.113883.6.96",
+          |						"CodeSystemName": "SNOMED CT",
+          |						"Name": "Intermittent"
+          |					},
+          |					"DateTime": "1994-01-01T05:00:00.000Z",
+          |					"AgeAtOnset": "40",
+          |					"IsCauseOfDeath": null
+          |				}
+          |			]
+          |		}
+          |	],
+          |	"Immunizations": [
+          |		{
+          |			"DateTime": "2012-05-10T04:00:00.000Z",
+          |			"Route": {
+          |				"Code": "C28161",
+          |				"CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |				"CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+          |				"Name": "Intramuscular injection"
+          |			},
+          |			"Product": {
+          |				"Manufacturer": "Health LS - Immuno Inc.",
+          |				"Code": "88",
+          |				"CodeSystem": "2.16.840.1.113883.6.59",
+          |				"CodeSystemName": "CVX",
+          |				"Name": "Influenza virus vaccine",
+          |				"LotNumber": null
+          |			},
+          |			"Dose": {
+          |				"Quantity": "50",
+          |				"Units": "mcg"
+          |			}
+          |		},
+          |		{
+          |			"DateTime": "2012-04-01T04:00:00.000Z",
+          |			"Route": {
+          |				"Code": "C28161",
+          |				"CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |				"CodeSystemName": "National Cancer Institute (NCI) Thesaurus",
+          |				"Name": "Intramuscular injection"
+          |			},
+          |			"Product": {
+          |				"Manufacturer": "Health LS - Immuno Inc.",
+          |				"Code": "103",
+          |				"CodeSystem": "2.16.840.1.113883.6.59",
+          |				"CodeSystemName": "CVX",
+          |				"Name": "Tetanus and diphtheria toxoids - preservative free",
+          |				"LotNumber": null
+          |			},
+          |			"Dose": {
+          |				"Quantity": "50",
+          |				"Units": "mcg"
+          |			}
+          |		}
+          |	],
+          |	"MedicalEquipment": [
+          |		{
+          |			"Status": null,
+          |			"StartDate": "1999-11-01T05:00:00.000Z",
+          |			"Quantity": "2",
+          |			"Product": {
+          |				"Code": "72506001",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Automatic implantable cardioverter/defibrillator"
+          |			}
+          |		},
+          |		{
+          |			"Status": "completed",
+          |			"StartDate": "1998-01-01T05:00:00.000Z",
+          |			"Quantity": null,
+          |			"Product": {
+          |				"Code": "304120007",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Total hip replacement prosthesis"
+          |			}
+          |		},
+          |		{
+          |			"Status": "completed",
+          |			"StartDate": "1999-01-01T05:00:00.000Z",
+          |			"Quantity": null,
+          |			"Product": {
+          |				"Code": "58938008",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Wheelchair"
+          |			}
+          |		}
+          |	],
+          |    "Medications": [
+          |        {
+          |            "Prescription": null,
+          |            "FreeTextSig": null,
+          |            "Dose": {
+          |                "Quantity": "4",
+          |                "Units": "mg"
+          |            },
+          |            "Rate": {
+          |                "Quantity": null,
+          |                "Units": null
+          |            },
+          |            "Route": {
+          |                "Code": "C38288",
+          |                "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |                "CodeSystemName": "NCI Thesaurus",
+          |                "Name": "Oral"
+          |            },
+          |         "Status": "active",
+          |            "StartDate": null,
+          |            "EndDate": null,
+          |            "Frequency": {
+          |                "Period": "8",
+          |                "Unit": "h"
+          |            },
+          |         "NumberOfRefillsRemaining": 2,
+          |            "Product": {
+          |                "Code": "104894",
+          |                "CodeSystem": "2.16.840.1.113883.6.88",
+          |                "CodeSystemName": "RxNorm",
+          |                "Name": "Ondansetron 4 Mg Po Tbdp"
+          |            },
+          |         "Extensions": {
+          |             "Indication": {
+          |                 "url": "https://api.redoxengine.com/extensions/indication",
+          |                 "coding": {
+          |                     "system": "2.16.840.1.113883.6.90",
+          |                     "code": "J18.1",
+          |                     "display": "Lobar pneumonia"
+          |                 }
+          |             },
+          |             "author-id": {
+          |                 "url": "https://api.redoxengine.com/extensions/author-id",
+          |                 "string": "7236481726"
+          |             },
+          |             "author-name": {
+          |                 "url": "https://api.redoxengine.com/extensions/author-name",
+          |                 "humanName": {
+          |                     "use": "usual",
+          |                     "text": "Billy Bob Smith",
+          |                     "family": "Smith",
+          |                     "given": [
+          |                         "Billy",
+          |                         "Bob"
+          |                     ]
+          |                 }
+          |             }
+          |            }
+          |     },
+          |        {
+          |            "Prescription": false,
+          |            "FreeTextSig": null,
+          |            "Dose": {
+          |                "Quantity": "0.09",
+          |                "Units": "mg/actuat"
+          |            },
+          |            "Rate": {
+          |                "Quantity": "90",
+          |                "Units": "ml/min"
+          |            },
+          |            "Route": {
+          |                "Code": "C38216",
+          |                "CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |                "CodeSystemName": "NCI Thesaurus",
+          |                "Name": "RESPIRATORY (INHALATION)"
+          |            },
+          |         "Status": "completed",
+          |            "StartDate": "2012-08-06T04:00:00.000Z",
+          |            "EndDate": "2012-08-13T04:00:00.000Z",
+          |            "Frequency": {
+          |                "Period": "12",
+          |                "Unit": "h"
+          |            },
+          |         "NumberOfRefillsRemaining": 1,
+          |            "Product": {
+          |                "Code": "573621",
+          |                "CodeSystem": "2.16.840.1.113883.6.88",
+          |                "CodeSystemName": "RxNorm",
+          |                "Name": "Albuterol 0.09 MG/ACTUAT inhalant solution"
+          |            },
+          |        "Extensions": {
+          |         "Indication": {
+          |             "url": "https://api.redoxengine.com/extensions/indication",
+          |             "coding": {
+          |                 "system": "2.16.840.1.113883.6.90",
+          |                 "code": "J18.1",
+          |                 "display": "Lobar pneumonia"
+          |             }
+          |         },
+          |         "author-id": {
+          |             "url": "https://api.redoxengine.com/extensions/author-id",
+          |             "string": "7236481726"
+          |         },
+          |         "author-name": {
+          |             "url": "https://api.redoxengine.com/extensions/author-name",
+          |             "humanName": {
+          |                 "use": "usual",
+          |                 "text": "Billy Bob Smith",
+          |                 "family": "Smith",
+          |                 "given": [
+          |                    "Billy",
+          |                    "Bob"
+          |                 ]
+          |             }
+          |         }
+          |        }
+          |  }
+          |    ],
+          |	"PlanOfCare": {
+          |		"Orders": [
+          |			{
+          |				"Code": "624-7",
+          |				"CodeSystem": "2.16.840.1.113883.6.1",
+          |				"CodeSystemName": null,
+          |				"Name": "Sputum Culture",
+          |				"Status": "Request",
+          |				"DateTime": "2012-08-20T05:00:00.000Z"
+          |			}
+          |		],
+          |		"Procedures": [
+          |			{
+          |				"Code": "168731009",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED-CT",
+          |				"Name": "Chest X-Ray",
+          |				"Status": "Request",
+          |				"DateTime": "2012-08-26T05:00:00.000Z"
+          |			}
+          |		],
+          |		"Encounters": [
+          |			{
+          |				"Code": "99241",
+          |				"CodeSystem": "2.16.840.1.113883.6.12",
+          |				"CodeSystemName": "CPT",
+          |				"Name": "Office consultation - 15 minutes",
+          |				"Status": "Intent",
+          |				"DateTime": "2012-08-20T05:00:00.000Z"
+          |			}
+          |		],
+          |		"MedicationAdministration": [
+          |			{
+          |				"Status": "Intent",
+          |				"Dose": {
+          |					"Quantity": "81",
+          |					"Units": "milliGRAM(s)"
+          |				},
+          |				"Rate": {
+          |					"Quantity": null,
+          |					"Units": null
+          |				},
+          |				"Route": {
+          |					"Code": "C38288",
+          |					"CodeSystem": "2.16.840.1.113883.3.26.1.1",
+          |					"CodeSystemName": "NCI Thesaurus",
+          |					"Name": "ORAL"
+          |				},
+          |				"StartDate": "2012-10-02T05:00:00.000Z",
+          |				"EndDate": "2012-10-31T04:59:00.000Z",
+          |				"Frequency": {
+          |					"Period": null,
+          |					"Unit": null
+          |				},
+          |				"Product": {
+          |					"Code": "1191",
+          |					"CodeSystem": "2.16.840.1.113883.6.88",
+          |					"CodeSystemName": "RxNorm",
+          |					"Name": "aspirin"
+          |				}
+          |			}
+          |		],
+          |		"Supplies": [],
+          |		"Services": [
+          |			{
+          |				"Code": "427519008",
+          |				"CodeSystem": "2.16.840.1.113883.11.20.9.34",
+          |				"CodeSystemName": "patientEducationType",
+          |				"Name": "Caregiver",
+          |				"Status": "Intent",
+          |				"DateTime": null
+          |			}
+          |		]
+          |	},
+          |	"Problems": [
+          |		{
+          |			"StartDate": "2012-08-06T04:00:00.000Z",
+          |			"EndDate": "2012-08-06T04:00:00.000Z",
+          |			"Code": "233604007",
+          |			"CodeSystem": "2.16.840.1.113883.6.96",
+          |			"CodeSystemName": "SNOMED CT",
+          |			"Name": "Pneumonia",
+          |			"Category": {
+          |				"Code": "409586006",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Complaint"
+          |			},
+          |			"HealthStatus": {
+          |				"Code": "162467007",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Symptom Free"
+          |			},
+          |			"Status": {
+          |				"Code": "413322009",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Resolved"
+          |			}
+          |		},
+          |		{
+          |			"StartDate": "2007-10-17T04:00:00.000Z",
+          |			"EndDate": "2012-08-06T04:00:00.000Z",
+          |			"Code": "195967001",
+          |			"CodeSystem": "2.16.840.1.113883.6.96",
+          |			"CodeSystemName": "SNOMED CT",
+          |			"Name": "Asthma",
+          |			"Category": {
+          |				"Code": "409586006",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Complaint"
+          |			},
+          |			"HealthStatus": {
+          |				"Code": "162467007",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Symptom Free"
+          |			},
+          |			"Status": {
+          |				"Code": "55561003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Active"
+          |			}
+          |		}
+          |	],
+          |	"Procedures": {
+          |		"Observations": [
+          |			{
+          |				"Code": "123456",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED-CT",
+          |				"Name": "Fake observation",
+          |				"DateTime": "20120807",
+          |				"Status": "active",
+          |				"TargetSite": {
+          |					"Code": "2.16.840.1.113883.6.96",
+          |					"CodeSystem": "2.16.840.1.113883.6.96",
+          |					"CodeSystemName": "SNOMED-CT",
+          |					"Name": "Entire hand (body structure)"
+          |				}
+          |			}
+          |		],
+          |		"Procedures": [
+          |			{
+          |				"Code": "168731009",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED-CT",
+          |				"Name": "Chest X-Ray",
+          |				"DateTime": "20120807",
+          |				"Status": "completed"
+          |			}
+          |		],
+          |		"Services": [
+          |			{
+          |				"Code": "123456",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED-CT",
+          |				"Name": "Fake action",
+          |				"DateTime": "20120807",
+          |				"Status": "aborted"
+          |			}
+          |		]
+          |	},
+          |	"Results": [
+          |		{
+          |			"Code": "43789009",
+          |			"CodeSystem": "2.16.840.1.113883.6.96",
+          |			"CodeSystemName": "SNOMED CT",
+          |			"Name": "CBC WO DIFFERENTIAL",
+          |			"Status": "Final",
+          |			"Observations": [
+          |				{
+          |					"Code": "30313-1",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "HGB",
+          |					"Status": "Final",
+          |					"Interpretation": "Normal",
+          |					"DateTime": null,
+          |					"Value": "10.2",
+          |                 "ValueType": "PhysicalQuantity",
+          |					"Units": "g/dl",
+          |					"ReferenceRange": {
+          |						"Low": null,
+          |						"High": null,
+          |						"Text": null
+          |					}
+          |				},
+          |				{
+          |					"Code": "33765-9",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "WBC",
+          |					"Status": "Final",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "2012-08-10T14:00:00.000Z",
+          |					"Value": "12.3",
+          |                 "ValueType": "PhysicalQuantity",
+          |					"Units": "10+3/ul",
+          |					"ReferenceRange": {
+          |						"Low": null,
+          |						"High": null,
+          |						"Text": null
+          |					}
+          |				},
+          |				{
+          |					"Code": "26515-7",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "PLT",
+          |					"Status": "Final",
+          |					"Interpretation": "Low",
+          |					"DateTime": "2012-08-10T14:00:00.000Z",
+          |					"Value": "123",
+          |                 "ValueType": "PhysicalQuantity",
+          |					"Units": "10+3/ul",
+          |					"ReferenceRange": {
+          |						"Low": null,
+          |						"High": null,
+          |						"Text": null
+          |					}
+          |				}
+          |			]
+          |		}
+          |	],
+          |	"SocialHistory": {
+          |		"Observations": [
+          |			{
+          |				"Code": "160573003",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Alcohol Consumption",
+          |				"Value": {
+          |					"Code": null,
+          |					"CodeSystem": null,
+          |					"CodeSystemName": null,
+          |					"Name": null
+          |				},
+          |				"ValueText": "None",
+          |				"StartDate": null,
+          |				"EndDate": null
+          |			}
+          |		],
+          |		"Pregnancy": [],
+          |		"TobaccoUse": [
+          |			{
+          |				"Code": "8517006",
+          |				"CodeSystem": "2.16.840.1.113883.6.96",
+          |				"CodeSystemName": "SNOMED CT",
+          |				"Name": "Former smoker",
+          |				"StartDate": null,
+          |				"EndDate": "2011-02-27T05:00:00.000Z"
+          |			}
+          |		]
+          |	},
+          |	"VitalSigns": [
+          |		{
+          |			"DateTime": null,
+          |			"Observations": [
+          |				{
+          |					"Code": "8302-2",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Height",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": null,
+          |					"Value": "177",
+          |					"Units": "cm"
+          |				},
+          |				{
+          |					"Code": "3141-9",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Patient Body Weight - Measured",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "1999-11-14T00:00:00.000Z",
+          |					"Value": "86",
+          |					"Units": "kg"
+          |				},
+          |				{
+          |					"Code": "8480-6",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Intravascular Systolic",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "1999-11-14T00:00:00.000Z",
+          |					"Value": "132",
+          |					"Units": "mm[Hg]"
+          |				}
+          |			]
+          |		},
+          |		{
+          |			"DateTime": "2000-04-07T00:00:00.000Z",
+          |			"Observations": [
+          |				{
+          |					"Code": "8302-2",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Height",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "2000-04-07T00:00:00.000Z",
+          |					"Value": "177",
+          |					"Units": "cm"
+          |				},
+          |				{
+          |					"Code": "3141-9",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Patient Body Weight - Measured",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "2000-04-07T00:00:00.000Z",
+          |					"Value": "88",
+          |					"Units": "kg"
+          |				},
+          |				{
+          |					"Code": "8480-6",
+          |					"CodeSystem": "2.16.840.1.113883.6.1",
+          |					"CodeSystemName": "LOINC",
+          |					"Name": "Intravascular Systolic",
+          |					"Status": "completed",
+          |					"Interpretation": "Normal",
+          |					"DateTime": "2000-04-07T00:00:00.000Z",
+          |					"Value": "145",
+          |					"Units": "mm[Hg]"
+          |				}
+          |			]
+          |		}
+          |	]
+          |}
+        """.stripMargin
+
+      val patientPush = validateJsonInput[PatientPush](json)
+
+      // Check chart deserialization
+
+      // Meta
+      val meta = patientPush.Meta
+      meta.EventType must be equalTo RedoxEventTypes.PatientPush
+      meta.Destinations must not be empty
+
+      // Header
+      val h = patientPush.Header
+      h.Document.Author must beSome
+      h.Document.Author.flatMap(_.Address) must beSome
+      h.Document.Visit must beSome
+      h.Document.Extensions must beSome
+      h.Patient.Identifiers must not be empty
+      h.Patient.Demographics must beSome
+      h.Patient.Demographics.flatMap(_.Address) must beSome
+      h.Patient.Demographics.flatMap(_.PhoneNumber) must beSome
+      h.Patient.Demographics.get.EmailAddresses must not be empty
+      h.Patient.Demographics.get.EmailAddresses.size must be equalTo (1)
+      h.Patient.Demographics.get.EmailAddresses.head.Address.get must be equalTo ("12313124@fake.com")
+
+      // Collections
+      patientPush.AdvanceDirectives must not be empty
+      patientPush.Allergies must not be empty
+      patientPush.Encounters must not be empty
+      patientPush.FamilyHistory must not be empty
+      patientPush.Immunizations must not be empty
+      patientPush.MedicalEquipment must not be empty
+      patientPush.Medications must not be empty
+      patientPush.PlanOfCare must beSome
+      patientPush.PlanOfCare.get.Encounters must not be empty
+      patientPush.PlanOfCare.get.MedicationAdministration must not be empty
+      patientPush.PlanOfCare.get.Orders must not be empty
+      patientPush.PlanOfCare.get.Procedures must not be empty
+      patientPush.PlanOfCare.get.Services must not be empty
+      patientPush.Problems must not be empty
+      patientPush.Procedures must beSome
+      patientPush.Procedures.get.Observations must not be empty
+      patientPush.Procedures.get.Procedures must not be empty
+      patientPush.Procedures.get.Services must not be empty
+      patientPush.Results must not be empty
+      patientPush.Results.head.Observations must not be empty
+      patientPush.Results.head.Observations.head.ValueType.get must be equalTo (ValueTypes.PhysicalQuantity)
+      patientPush.Results.head.Observations(1).ValueType.get must be equalTo (ValueTypes.PhysicalQuantity)
+      patientPush.Results.head.Observations(2).ValueType.get must be equalTo (ValueTypes.PhysicalQuantity)
+      patientPush.SocialHistory must beSome
+      patientPush.SocialHistory.get.Observations must not be empty
+      patientPush.SocialHistory.get.TobaccoUse must not be empty
+      patientPush.VitalSigns must not be empty
+      patientPush.VitalSigns.head.Observations must not be empty
+
+      // Check request and response message
+
+      val fut = client.post[PatientPush, EmptyResponse](patientPush)
+      val maybe = handleResponse(fut)
+      maybe must beSome
+    }
+  }
 }

--- a/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
+++ b/src/test/scala/com/github/vitalsoftware/scalaredox/ClinicalSummaryTest.scala
@@ -2192,7 +2192,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
           |}
         """.stripMargin
 
-      val patientPush = validateJsonInput[PatientPush](json)
+      val patientPush = validateJsonInput[clinicalsummary.inbound.PatientPush](json)
 
       // Check chart deserialization
 
@@ -2247,7 +2247,7 @@ class ClinicalSummaryTest extends Specification with RedoxTest {
 
       // Check request and response message
 
-      val fut = client.post[PatientPush, EmptyResponse](patientPush)
+      val fut = client.post[clinicalsummary.inbound.PatientPush, EmptyResponse](patientPush)
       val maybe = handleResponse(fut)
       maybe must beSome
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.2.0"
+version in ThisBuild := "10.3.0"


### PR DESCRIPTION
## Purpose
Redox informed us that required fields on their api does not necessarily mean they will not be null. We need to consider this and such create a PatientPush model such that every field is optional.


## Approach
Create a separate package where we define the models again with every field optional. If used models has already all-optional fields, we use that.
