### PR TITLE
Atilla/in 497/fix date without timezone in inbound patientpush

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/AdvanceDirective.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/AdvanceDirective.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, BasicPerson, Code }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Advance directive documents that the healthcare organization has on file for the patient.
@@ -22,8 +20,8 @@ import org.joda.time.DateTime
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime],
+  StartDate: Option[String] = None,
+  EndDate: Option[String],
   ExternalReference: Option[String],
   VerifiedBy: Seq[BasicPerson] = Seq.empty, // Todo missing VerifiedBy.DateTime
   Custodians: Seq[BasicPerson] = Seq.empty

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Allergy.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Allergy.scala
@@ -1,0 +1,41 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.scalaredox.models.{BasicCode, CodeWithText}
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ *
+ * @param Type A code for the type of allergy intolerance this is (food, drug, etc.). Allergy/Adverse Event Type Value Set
+ * @param Substance The substance that the causes the alergy/intolerance. Brand names and generics will be coded in RxNorm. Drug classes use NDF-RT, and foods use UNII
+ * @param Reaction A code for the reaction caused by the allergy (dissiness, hives ,etc.). SNOMED CT
+ * @param Severity A code for the severity of the reaction (moderate, severe, etc.). SNOMED CT
+ * @param Status The current status of the Allergy (active, historic, etc.). SNOMED CT (Active, Inactive, Resolved)
+ * @param StartDate When the allergy was first noted. ISO 8601 Format
+ * @param EndDate When the allergy was no longer a problem (if applicable). ISO 8601 Format
+ * @param Comment Free text comment about the allergy.
+ */
+@jsonDefaults case class Allergy(
+  Type: BasicCode = BasicCode(),
+  Substance: BasicCode = BasicCode(),
+  Reaction: Seq[CodeWithText] = Seq.empty,
+  Severity: BasicCode = BasicCode(),
+  Status: BasicCode = BasicCode(),
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
+  Comment: Option[String] = None
+)
+
+object Allergy extends RobustPrimitives
+
+/**
+ * describes any medication allergies, food allergies, or reactions to other substances
+ * (such as latex, iodine, tape adhesives). At a minimum, it should list currently active
+ * and relevant historical allergies and adverse reactions.
+ */
+@jsonDefaults case class AllergiesMessage(
+  AllergyText: Option[String] = None,
+  Allergies: Seq[Allergy] = Seq.empty
+)
+
+object AllergiesMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/ClinicalSummaryTraits.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/ClinicalSummaryTraits.scala
@@ -1,0 +1,11 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.scalaredox.models.Meta
+
+trait ClinicalSummaryLike {
+  def Meta: Meta
+}
+
+trait HasClinicalSummaryPatient {
+  def Patient: Patient
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Common.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Common.scala
@@ -1,7 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ Address, BasicCode }
 import com.github.vitalsoftware.util.RobustPrimitives
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Demographics.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Demographics.scala
@@ -1,0 +1,47 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.scalaredox.models._
+
+import scala.collection.Seq
+
+/**
+ * //////////////////////////////////////////////////////////
+ *              CLINICAL SUMMARY FIELDS
+ * //////////////////////////////////////////////////////////
+ */
+/**
+ * About a clinical summary demographics.
+ *
+ * @param FirstName Required
+ * @param LastName Required
+ * @param DOB Partially reliable. Patient's date of birth. In ISO 8601 format
+ * @param SSN Patient SSN.
+ * @param Sex Required
+ * @param Address Patient's addresses.
+ * @param PhoneNumber Patient's phone numbers.
+ * @param EmailAddresses Patient's email addresses.
+ * @param Language Patient's primary spoken language. In ISO 639-1 alpha values (e.g. 'en'). http://www.mathguide.de/info/tools/languagecode.html
+ * @param Race List at http://phinvads.cdc.gov/vads/ViewValueSet.action?id=66D34BBC-617F-DD11-B38D-00188B398520
+ * @param Ethnicity List at https://phinvads.cdc.gov/vads/ViewValueSet.action?id=35D34BBC-617F-DD11-B38D-00188B398520
+ * @param Religion List at https://www.hl7.org/fhir/v3/ReligiousAffiliation/index.html
+ * @param MaritalStatus List at http://www.hl7.org/FHIR/v2/0002/index.html
+ */
+@jsonDefaults case class Demographics(
+  FirstName: String,
+  MiddleName: Option[String] = None,
+  LastName: String,
+  DOB: String,
+  SSN: Option[String] = None,
+  Sex: SexType.Value = SexType.Unknown,
+  Address: Option[Address] = None,
+  PhoneNumber: Option[PhoneNumber] = None,
+  EmailAddresses: Seq[EmailAddress] = Seq.empty,
+  Language: Option[Language] = None,
+  Race: Option[RaceType.Value] = None,
+  Ethnicity: Option[String] = None,
+  Religion: Option[String] = None,
+  MaritalStatus: Option[String] = None
+)
+
+

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Encounter.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ Address, BasicCode, Provider }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  *
@@ -19,8 +17,8 @@ import org.joda.time.DateTime
 @jsonDefaults case class Encounter(
   Identifiers: Seq[Identifier] = Seq.empty,
   Type: BasicCode = BasicCode(),
-  DateTime: Option[DateTime] = None,
-  EndDateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
+  EndDateTime: Option[String] = None,
   Providers: Seq[Provider] = Seq.empty,
   Locations: Seq[Location] = Seq.empty,
   Diagnosis: Seq[BasicCode] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/FamilyHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/FamilyHistory.scala
@@ -1,7 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ FamilyHistoryProblem, Relation }
 import com.github.vitalsoftware.util.RobustPrimitives
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Header.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Header.scala
@@ -1,0 +1,24 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.scalaredox.models.Provider
+import com.github.vitalsoftware.scalaredox.models.clinicalsummary.Document
+
+/**
+ * Information about the clinical summary's patient and where the summary came from
+ *
+ * @param DirectAddressFrom The sender's Direct address, if one or both sides are using Direct messaging.
+ * @param DirectAddressTo The recipient's Direct address, if one or both sides are using Direct messaging.
+ * @param Document An object containing metadata about the document being pushed to the destination.
+ * @param Patient Patient
+ * @param PCP Provider
+ */
+@jsonDefaults case class Header(
+  DirectAddressFrom: Option[String] = None,
+  DirectAddressTo: Option[String] = None,
+  Document: Document,
+  Patient: Patient,
+  PCP: Option[Provider] = None,
+) extends HasClinicalSummaryPatient
+
+

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Immunization.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Immunization.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Dose, ImmunizationProduct }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Immunization given.
@@ -15,7 +13,7 @@ import org.joda.time.DateTime
  * @param Dose Dosage
  */
 @jsonDefaults case class Immunization(
-  DateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
   Route: Option[BasicCode] = None,
   Product: Option[ImmunizationProduct] = None,
   Dose: Option[Dose] = None

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Insurance.scala
@@ -1,0 +1,132 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.util.RobustPrimitives
+import com.github.vitalsoftware.scalaredox.models.Address
+import com.github.vitalsoftware.scalaredox.models.PhoneNumber
+import play.api.libs.json.{ Format, Reads, Writes }
+
+/**
+ *
+ * @param ID Identifier of insurance plan
+ * @param IDType ID type of insurance plan
+ * @param Name Name of insurance plan
+ */
+@jsonDefaults case class InsurancePlan(
+  ID: Option[String] = None,
+  IDType: Option[String] = None,
+  Name: Option[String] = None
+)
+
+object InsurancePlan extends RobustPrimitives
+
+/**
+ *
+ * @param ID ID of insurance company (payor)
+ * @param IDType ID type of insurance company (payor)
+ * @param Name Name of insurance company (payor)
+ * @param Address Insurance company's address
+ * @param PhoneNumber Insurance companys phone number. In E. 164 Format (i.e. +16085551234)
+ */
+@jsonDefaults case class InsuranceCompany(
+  ID: Option[String] = None,
+  IDType: Option[String] = None,
+  Name: Option[String] = None,
+  Address: Option[Address] = None,
+  PhoneNumber: Option[String] = None
+)
+
+object InsuranceCompany extends RobustPrimitives
+
+object InsuranceRelationshipTypes extends Enumeration {
+  val Self, Spouse, Other = Value
+
+  def defaultValue = Other
+  @transient implicit lazy val jsonFormat: Format[InsuranceRelationshipTypes.Value] =
+    Format(Reads.enumNameReads(InsuranceRelationshipTypes), Writes.enumNameWrites)
+}
+
+object InsuranceAgreementTypes extends Enumeration {
+  val Standard, Unified, Maternity, Other = Value
+
+  def defaultValue = Other
+  @transient implicit lazy val jsonFormat: Format[InsuranceAgreementTypes.Value] =
+    Format(Reads.enumNameReads(InsuranceAgreementTypes), Writes.enumNameWrites)
+}
+
+object InsuranceCoverageTypes extends Enumeration {
+  val Patient, Clinic, Insurance, Other = Value
+
+  def defaultValue = Other
+  @transient implicit lazy val jsonFormat: Format[InsuranceCoverageTypes.Value] =
+    Format(Reads.enumNameReads(InsuranceCoverageTypes), Writes.enumNameWrites)
+}
+
+/** Individual who has the agreement with the insurance company for the related policy */
+@jsonDefaults case class InsuredPerson(
+  FirstName: Option[String] = None,
+  LastName: Option[String] = None,
+  DOB: Option[String] = None,
+  Address: Option[Address] = None,
+  Relationship: Option[String] = None,
+  PhoneNumber: Option[PhoneNumber] = None
+)
+
+object InsuredPerson extends RobustPrimitives
+
+/** Guarantor's Employer */
+@jsonDefaults case class Employer(
+  Name: Option[String] = None,
+  Address: Option[Address] = None,
+  PhoneNumber: Option[String] = None
+)
+
+object Employer extends RobustPrimitives
+
+/**
+ * Person ultimately responsible for the bill of the appointment
+ *
+ * @param RelationToPatient Relation to the patient. E.x. self, parent
+ * @param Type Type of guarantor. E.g. institution, individual
+ * @param Employer Guarantor's employer
+ */
+@jsonDefaults case class Guarantor(
+  FirstName: Option[String] = None,
+  LastName: Option[String] = None,
+  DOB: Option[String] = None,
+  Address: Option[Address] = None,
+  RelationToPatient: Option[String] = None,
+  PhoneNumber: Option[PhoneNumber] = None,
+  Type: Option[String] = None,
+  Employer: Option[Employer] = None
+)
+
+object Guarantor extends RobustPrimitives
+
+/**
+ * List of insurance coverages for the patient
+ * @param Plan Insurance plan
+ * @param Company Insurance company
+ * @param GroupNumber Insurance policy group number
+ * @param GroupName Insurance policy group name
+ * @param EffectiveDate Effect date of this insurance policy. In YYYY-MM-DD format
+ * @param ExpirationDate Expiration date of this insurance policy. In YYYY-MM-DD format
+ * @param PolicyNumber Insurance policy number
+ * @param AgreementType Type of insurance agreement. One of the following: "Standard", "Unified", "Maternity"
+ * @param CoverageType Type of insurance agreement. One of the following: "Patient", "Clinic", "Insurance", "Other". Indicates who will be receiving the bill for the service.
+ * @param Insured Individual who has the agreement with the insurance company for the related policy
+ */
+@jsonDefaults case class Insurance(
+  Plan: Option[InsurancePlan] = None,
+  Company: Option[InsuranceCompany] = None,
+  GroupNumber: Option[String] = None,
+  GroupName: Option[String] = None,
+  EffectiveDate: Option[String] = None,
+  ExpirationDate: Option[String] = None,
+  PolicyNumber: Option[String] = None,
+  AgreementType: Option[InsuranceAgreementTypes.Value] = None,
+  CoverageType: Option[InsuranceCoverageTypes.Value] = None,
+  Insured: Option[InsuredPerson] = None
+)
+
+object Insurance extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/MedicalEquipment.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/MedicalEquipment.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.BasicCode
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Piece of medical equipment.
@@ -16,7 +14,7 @@ import org.joda.time.DateTime
  */
 @jsonDefaults case class MedicalEquipment(
   Status: Option[String] = None,
-  StartDate: Option[DateTime] = None,
+  StartDate: Option[String] = None,
   Quantity: Option[String] = None, // Todo Int?
   Product: BasicCode = BasicCode()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Medication.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Medication.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, Dose, MedicationExtension, TimePeriod }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * @param Prescription Whether the medication is a prescription. For a prescription: true. For a patient reported med, or a med administered by a provider: false
@@ -17,8 +15,8 @@ import org.joda.time.DateTime
   Rate: Option[Dose] = None,
   Route: Option[BasicCode] = None,
   Status: Option[String] = None,
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime] = None,
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
   Frequency: Option[TimePeriod] = None,
   NumberOfRefillsRemaining: Option[Double] = None,
   IsPRN: Option[Boolean] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Patient.scala
@@ -1,0 +1,12 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros.jsonDefaults
+
+import scala.collection.Seq
+
+@jsonDefaults case class Patient(
+  Identifiers: Seq[Identifier],
+  Demographics: Option[Demographics] = None,
+)
+
+

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PatientPush.scala
@@ -1,11 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{ Allergy, Insurance, Meta, Problem }
-import com.github.vitalsoftware.scalaredox.models.clinicalsummary.{ ClinicalSummaryLike, Header }
+import com.github.vitalsoftware.scalaredox.models.Meta
 import com.github.vitalsoftware.util.RobustPrimitives
-import play.api.libs.json.JodaWrites._
-import play.api.libs.json.JodaReads._
 
 import scala.collection.Seq
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/PlanOfCare.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, CodeWithStatus, Dose, TimePeriod }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Medication to be given.
@@ -14,8 +12,8 @@ import org.joda.time.DateTime
   Dose: Option[Dose] = None,
   Rate: Option[Dose] = None,
   Route: Option[BasicCode] = None,
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime] = None,
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
   Frequency: Option[TimePeriod] = None,
   Product: BasicCode = BasicCode()
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Problem.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Problem.scala
@@ -1,0 +1,43 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
+
+import com.github.vitalsoftware.macros._
+import com.github.vitalsoftware.scalaredox.models.BasicCode
+import com.github.vitalsoftware.scalaredox.models.Code
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ *
+ * @param StartDate When the problem was noticed. ISO 8601 Format
+ * @param EndDate When the problem stopped (if it is not current). ISO 8601 Format
+ * @param Code The code for the problem. . SNOMED-CT Code. Limited to terms descending from the Clinical Findings (404684003) or Situation with Explicit Context (243796009)
+ * @param Category What type of problem this is (complaint, diagnosis, symptom, etc.)
+ * HealthStatus The effect of the problem on the patient (chronically ill, in remission, etc.). SNOMED-CT
+ * @param Status The current state of the problem (active, inactive, resolved). HITSPProblemStatus
+ */
+@jsonDefaults case class Problem(
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
+  Code: Option[String] = None,
+  CodeSystem: Option[String] = None,
+  CodeSystemName: Option[String] = None,
+  Name: Option[String] = None,
+  Category: BasicCode = BasicCode(),
+  HealthStatus: BasicCode = BasicCode(),
+  Status: Option[BasicCode] = None,
+  Comment: Option[String] = None,
+) extends Code
+
+object Problem extends RobustPrimitives
+
+/**
+ * This section contains the patient's past and current relevant medical problems.
+ *
+ * @param ProblemsText Free text form of the problems summary
+ * @param Problems An array of all of patient relevant problems, current and historical.
+ */
+@jsonDefaults case class ProblemsMessage(
+  ProblemsText: Option[String] = None,
+  Problems: Seq[Problem] = Seq.empty
+)
+
+object ProblemsMessage extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Procedures.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Procedures.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{ BasicCode, CodeWithStatus }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Procedure observation
@@ -16,7 +14,7 @@ import org.joda.time.DateTime
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  DateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
   Status: Option[String] = None,
   TargetSite: Option[BasicCode] = None,
 )

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
@@ -1,14 +1,25 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{
-  BasicCode,
-  ChartResultProducer,
-  Code,
-  Status,
-  ValueTypes
-}
+import com.github.vitalsoftware.scalaredox.models.{ BasicCode, ChartResultProducer, Code, Status, ValueTypes }
 import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ * Reference range for the result.
+ * Numeric result values will use the low and high properties.
+ * Non-numeric result values will put the normal value in the text property.
+ *
+ * @param Low Lower bound for a normal result
+ * @param High Upper bound for a normal result
+ * @param Text The normal value for non-numeric results
+ */
+@jsonDefaults case class ReferenceRange(
+  Low: Option[String] = None,
+  High: Option[String] = None,
+  Text: Option[String] = None
+)
+
+object ReferenceRange extends RobustPrimitives
 
 /**
  * Result observation
@@ -52,20 +63,3 @@ object ResultObservation extends RobustPrimitives
     with Status
 
 object ChartResult extends RobustPrimitives
-
-/**
- * Reference range for the result.
- * Numeric result values will use the low and high properties.
- * Non-numeric result values will put the normal value in the text property.
- *
- * @param Low Lower bound for a normal result
- * @param High Upper bound for a normal result
- * @param Text The normal value for non-numeric results
- */
-@jsonDefaults case class ReferenceRange(
- Low: Option[String] = None,
- High: Option[String] = None,
- Text: Option[String] = None
-)
-
-object ReferenceRange extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
@@ -53,3 +53,20 @@ object ResultObservation extends RobustPrimitives
     with Status
 
 object ChartResult extends RobustPrimitives
+
+/**
+ * Reference range for the result.
+ * Numeric result values will use the low and high properties.
+ * Non-numeric result values will put the normal value in the text property.
+ *
+ * @param Low Lower bound for a normal result
+ * @param High Upper bound for a normal result
+ * @param Text The normal value for non-numeric results
+ */
+@jsonDefaults case class ReferenceRange(
+ Low: Option[String] = None,
+ High: Option[String] = None,
+ Text: Option[String] = None
+)
+
+object ReferenceRange extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
@@ -5,7 +5,6 @@ import com.github.vitalsoftware.scalaredox.models.{
   BasicCode,
   ChartResultProducer,
   Code,
-  ReferenceRange,
   Status,
   ValueTypes
 }

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Result.scala
@@ -1,7 +1,6 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.{
   BasicCode,
   ChartResultProducer,
@@ -11,7 +10,6 @@ import com.github.vitalsoftware.scalaredox.models.{
   ValueTypes
 }
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Result observation
@@ -26,7 +24,7 @@ import org.joda.time.DateTime
   AltCodes: Option[Seq[BasicCode]] = None,
   Status: Option[String] = None,
   Interpretation: Option[String] = None, // Used by Result
-  DateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
   CodedValue: Option[BasicCode] = None, // Used by Result
   Value: Option[String] = None,
   ValueType: Option[ValueTypes.Value] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/SocialHistory.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/SocialHistory.scala
@@ -1,10 +1,8 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.scalaredox.models.BasicCode
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * @param Code A code for the observation (exercise, alcohol intake, etc.) . SNOMED CT
@@ -16,8 +14,8 @@ import org.joda.time.DateTime
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime] = None,
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
   Value: Option[BasicCode] = None,
   ValueText: Option[String] = None
 )
@@ -30,8 +28,8 @@ object SocialHistoryObservation extends RobustPrimitives
  * @param EstimatedDelivery Estimate delivery date if pregnancy is still active.
  */
 @jsonDefaults case class Pregnancy(
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime] = None,
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None,
   EstimatedDelivery: Option[String] = None
 )
 
@@ -47,8 +45,8 @@ object Pregnancy extends RobustPrimitives
   CodeSystem: Option[String] = None,
   CodeSystemName: Option[String] = None,
   Name: Option[String] = None,
-  StartDate: Option[DateTime] = None,
-  EndDate: Option[DateTime] = None
+  StartDate: Option[String] = None,
+  EndDate: Option[String] = None
 )
 
 object TobaccoUse extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/VitalSigns.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/VitalSigns.scala
@@ -1,9 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary.inbound
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 import com.github.vitalsoftware.util.RobustPrimitives
-import org.joda.time.DateTime
 
 /**
  * Vital sign observation
@@ -17,7 +15,7 @@ import org.joda.time.DateTime
   Name: Option[String] = None,
   Status: Option[String] = None,
   Interpretation: Option[String] = None,
-  DateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
   Value: Option[String] = None,
   Units: Option[String] = None,
 )
@@ -30,7 +28,7 @@ object VitalSignObservation extends RobustPrimitives
  *                     Subset of LOINC codes (HITSP Vital Sign Result Type).
  */
 @jsonDefaults case class VitalSigns(
-  DateTime: Option[DateTime] = None,
+  DateTime: Option[String] = None,
   Observations: Seq[VitalSignObservation] = Seq.empty
 )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.4.1-RC1"
+version in ThisBuild := "10.4.1-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.3.1"
+version in ThisBuild := "10.4.1-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.4.1-RC2"
+version in ThisBuild := "10.4.1"


### PR DESCRIPTION
## Purpose
✅  If a date contains timezone info in the ccda file redox converts this date correctly.
✅  If a date contains time, redox can calculate right date time with Source's timezone setting. 
😡  However, Redox doesn't add timezone to a `date without time`. In an other words, If a date in ccda is in `yyyyMMdd` format redox just passes this date as it is with `yyyy-MM-dd` format.

In our scala-redox lib we have joda.time.DateTime type for date fields. If date is in `yyyy-MM-dd` format, then our lib convert this date in UTC timezone. This causes 6 hours gap for our Colorado import because of timezone (Denver is GMT-6). 

## Approach
We changed all `DateTime`s to `String`s in our inbound PatientPush and we will calculate right epoch in our api using acquired clinic timezone (we will add timezone field into  ccdaImportJob). I will open another PR for api changes.

## Learning
https://developer.redoxengine.com/onboarding/

![image](https://user-images.githubusercontent.com/77263541/145350674-c6d216c3-ce07-4737-b688-fcc785bbcbf0.png)