### PR TITLE
Change inbound insurance enum fields to strings

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Insurance.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/inbound/Insurance.scala
@@ -124,8 +124,8 @@ object Guarantor extends RobustPrimitives
   EffectiveDate: Option[String] = None,
   ExpirationDate: Option[String] = None,
   PolicyNumber: Option[String] = None,
-  AgreementType: Option[InsuranceAgreementTypes.Value] = None,
-  CoverageType: Option[InsuranceCoverageTypes.Value] = None,
+  AgreementType: Option[String] = None,
+  CoverageType: Option[String] = None,
   Insured: Option[InsuredPerson] = None
 )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.4.1"
+version in ThisBuild := "10.4.2"


### PR DESCRIPTION
## Purpose
Some of Colorado QA Clinical Summaries fail because CCD-A insurance coverage type does not match the enums in scala-redox library. We do not import these info, so we convert it to a string because we will not use it.