### PR TITLE
Add previousIdentifiers to patient object

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -144,6 +144,7 @@ object RedoxClient {
         case (Inventory, _)                                          => Left(unsupported)
         case (Media, _)                                              => Right(implicitly[Reads[models.MediaMessage]])
         case (Notes, _)                                              => Right(implicitly[Reads[models.NoteMessage]])
+        case (PatientAdmin, PatientMerge)                            => Right(implicitly[Reads[models.PatientAdminMergedMessage]])
         case (PatientAdmin, _)                                       => Right(implicitly[Reads[models.PatientAdminMessage]])
         case (PatientSearch, _)                                      => Right(implicitly[Reads[models.PatientSearch]])
         case (Referral, _)                                           => Left(unsupported)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasPatient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasPatient.scala
@@ -3,3 +3,7 @@ package com.github.vitalsoftware.scalaredox.models
 trait HasPatient {
   def Patient: Patient
 }
+
+trait HasMergedPatient {
+  def Patient: MergedPatient
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -97,6 +97,20 @@ object Contact extends RobustPrimitives
  */
 @jsonDefaults case class Patient(
   Identifiers: Seq[Identifier] = Seq.empty,
+  Demographics: Option[Demographics] = None,
+  Notes: Seq[String] = Seq.empty,
+  Contacts: Seq[Contact] = Seq.empty,
+  Guarantor: Option[Guarantor] = None,
+  Insurances: Seq[Insurance] = Seq.empty,
+  Diagnoses: Seq[CodesetWithName] = Seq.empty,
+  PCP: Option[Provider] = None
+)
+
+/**
+ * Merged Patient has extra "previous identifiers" to indicate retired MRNs
+ */
+@jsonDefaults case class MergedPatient(
+  Identifiers: Seq[Identifier] = Seq.empty,
   PreviousIdentifiers: Seq[Identifier] = Seq.empty,
   Demographics: Option[Demographics] = None,
   Notes: Seq[String] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -97,6 +97,7 @@ object Contact extends RobustPrimitives
  */
 @jsonDefaults case class Patient(
   Identifiers: Seq[Identifier] = Seq.empty,
+  PreviousIdentifiers: Seq[Identifier] = Seq.empty,
   Demographics: Option[Demographics] = None,
   Notes: Seq[String] = Seq.empty,
   Contacts: Seq[Contact] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -7,6 +7,7 @@ import scala.collection.Seq
 
 sealed trait RedoxMessage extends MetaLike
 sealed trait PatientRedoxMessage extends RedoxMessage with HasPatient
+sealed trait PatientMergedRedoxMessage extends RedoxMessage with HasMergedPatient
 sealed trait VisitRedoxMessage extends PatientRedoxMessage with HasVisit
 
 /**
@@ -183,7 +184,7 @@ object PatientSearch extends RobustPrimitives
 
 /**
  * Meta.DataModel: "PatientAdmin",
- * Meta.EventType: {Arrival, Cancel, Discharge, NewPatient, PatientUpdate, PatientMerge, PreAdmit, Registration, Transfer, VisitMerge, VisitUpdate}
+ * Meta.EventType: {Arrival, Cancel, Discharge, NewPatient, PatientUpdate, PreAdmit, Registration, Transfer, VisitMerge, VisitUpdate}
  */
 @jsonDefaults case class PatientAdminMessage(
   Meta: Meta,
@@ -193,6 +194,17 @@ object PatientSearch extends RobustPrimitives
     with HasVisitInfo
 
 object PatientAdminMessage extends RobustPrimitives
+
+/**
+ * Meta.DataModel: "PatientAdmin",
+ * Meta.EventType: "PatientMerge"
+ */
+@jsonDefaults case class PatientAdminMergedMessage(
+  Meta: Meta,
+  Patient: MergedPatient,
+) extends PatientMergedRedoxMessage
+
+object PatientAdminMergedMessage extends RobustPrimitives
 
 /**
  * Results messages communicate results of diagnostic tests such as labs, radiology imaging, etc.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.4.3"
+version in ThisBuild := "10.5.0"


### PR DESCRIPTION
PatientMerge event type requires the patient object have a `previousIdentifiers` list that indicates the retired MRNs.