### PR TITLE
Add organization datamodel + more event types

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -146,6 +146,7 @@ object RedoxClient {
         case (Notes, _)                                              => Right(implicitly[Reads[models.NoteMessage]])
         case (PatientAdmin, PatientMerge)                            => Right(implicitly[Reads[models.PatientAdminMergedMessage]])
         case (PatientAdmin, _)                                       => Right(implicitly[Reads[models.PatientAdminMessage]])
+        case (PatientSearch, _)                                      => Right(implicitly[Reads[models.PatientSearch]])
         case (Referral, _)                                           => Left(unsupported)
         case (Results, _)                                            => Right(implicitly[Reads[models.ResultsMessage]])
         case (Scheduling, _)                                         => Left(unsupported)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/client/RedoxClient.scala
@@ -146,7 +146,6 @@ object RedoxClient {
         case (Notes, _)                                              => Right(implicitly[Reads[models.NoteMessage]])
         case (PatientAdmin, PatientMerge)                            => Right(implicitly[Reads[models.PatientAdminMergedMessage]])
         case (PatientAdmin, _)                                       => Right(implicitly[Reads[models.PatientAdminMessage]])
-        case (PatientSearch, _)                                      => Right(implicitly[Reads[models.PatientSearch]])
         case (Referral, _)                                           => Left(unsupported)
         case (Results, _)                                            => Right(implicitly[Reads[models.ResultsMessage]])
         case (Scheduling, _)                                         => Left(unsupported)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
@@ -86,5 +86,5 @@ object SimpleCode extends RobustPrimitives
   Type: Option[String],
   System: Option[String],
   Value: Option[String],
-) extends SimpleCode
+)
 object SimpleCodeWithType extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Code.scala
@@ -75,3 +75,16 @@ object BasicCodeset extends RobustPrimitives
 ) extends Codeset
 
 object CodesetWithName extends RobustPrimitives
+
+@jsonDefaults case class SimpleCode(
+    System: Option[String],
+    Value: Option[String],
+)
+object SimpleCode extends RobustPrimitives
+
+@jsonDefaults case class SimpleCodeWithType(
+  Type: Option[String],
+  System: Option[String],
+  Value: Option[String],
+) extends SimpleCode
+object SimpleCodeWithType extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Meta.scala
@@ -22,10 +22,10 @@ object RedoxEventTypes extends Enumeration {
   val QueryResponse: Value = Value("Query Response")
   // format: off
   val Arrival, AvailableSlots, AvailableSlotsResponse, Booked, BookedResponse, Cancel, Delete, Deplete, Discharge,
-      GroupedOrders, Modification, Modify, New, NewPatient, NewUnsolicited, NoShow, PatientMerge, PatientQuery,
-      PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, Query, Registration, Replace,
-      Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, VisitQuery, VisitQueryResponse,
-      VisitPush, VisitUpdate, Administration, Invalid = Value
+      DocumentGet, DocumentQuery, GroupedOrders, LocationQuery,  Modification, Modify, New, NewPatient, NewUnsolicited, 
+      NoShow, PatientMerge, PatientQuery, PatientQueryResponse, PatientPush, PatientUpdate, Payment, PreAdmit, Push, 
+      Query, Registration, Replace, Reschedule, Response, Submission, Transaction, Transfer, Update, VisitMerge, 
+      VisitQuery, VisitQueryResponse, VisitPush, VisitUpdate, Administration, Invalid = Value
   // format: on
 
   @transient implicit lazy val jsonFormat: Format[RedoxEventTypes.Value] =

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
@@ -6,8 +6,8 @@ import play.api.libs.json.{ Format, Reads, Writes }
 import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 
 @jsonDefaults case class OrganizationEntry(
-    Active: Boolean,
-    Name: String,
+    Active: Option[Boolean] = None,
+    Name: Option[String]  = None,
     Aliases: Seq[String] = Seq.empty,
     Identifiers: Seq[Identifier] = Seq.empty,
     Type: Option[SimpleCode] = None,
@@ -18,11 +18,6 @@ import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
     DestinationID: Option[String] = None,
 )
 object OrganizationEntry extends RobustPrimitives
-
-@jsonDefaults case class OrganizationIdentifiers(
-    Identifiers: Seq[Identifier] = Seq.empty
-)
-object OrganizationIdentifiers extends RobustPrimitives
 
 @jsonDefaults case class OrganizationAttributes(
     Transaction: Option[String] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
@@ -1,0 +1,50 @@
+package com.github.vitalsoftware.scalaredox.models
+
+@jsonDefaults case class OrganizationEntry(
+    Active: Boolean,
+    Name: String,
+    Aliases: Seq[String] = Seq.empty,
+    Identifiers: Seq[Identifier] = Seq.empty,
+    Type: Option[SimpleCode] = None,
+    PartOf: Option[SimpleCodeWithType] = None,
+    Contacts: Seq[String] = None,
+    Address: Option[Address] = None,
+    Endpoints: Seq[String] = Seq.empty,
+    DestinationID: Option[String] = None,
+)
+object OrganizationEntry extends RobustPrimitives
+
+@jsonDefaults case class OrganizationEndpoint(
+    Name: String,
+    Identifiers: Seq[SimpleCodeWithType] = Seq.empty,
+    ConnectionType: Option[SimpleCode] = None,
+    Address: Option[String] = None,
+    MIMEType: Option[String] = None,
+    Attributes: Option[OrganizationAttributes] = None,
+)
+object OrganizationEndpoint extends RobustPrimitives
+
+@jsonDefaults case class OrganizationAttributes(
+    Transaction: Option[String] = None,
+    Actor: Option[SimpleCode] = None,
+    Version: Option[SimpleCode] = None,
+    UseCases: Seq[SimpleCode] = Seq.empty,
+    PurposeOfUse: Seq[SimpleCode] = Seq.empty,
+    Roles: Seq[SimpleCode] = Seq.empty,
+)
+object OrganizationAttributes extends RobustPrimitives
+
+@jsonDefaults case class OrganizationNameSearch(
+    SearchType: Option[String], // exact | partOf
+    Value: Option[String],
+)
+
+@jsonDefaults case class OrganizationRadiusSearch(
+    ZipCode: Option[String],
+    Radius: Option[String],
+)
+
+@jsonDefaults case class OrganizationPaging(
+    Count: Option[Int],
+    Index: Option[Int],
+)

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
@@ -1,5 +1,10 @@
 package com.github.vitalsoftware.scalaredox.models
 
+import com.github.vitalsoftware.util.RobustPrimitives
+import com.github.vitalsoftware.macros.jsonDefaults
+import play.api.libs.json.{ Format, Reads, Writes }
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+
 @jsonDefaults case class OrganizationEntry(
     Active: Boolean,
     Name: String,
@@ -7,22 +12,12 @@ package com.github.vitalsoftware.scalaredox.models
     Identifiers: Seq[Identifier] = Seq.empty,
     Type: Option[SimpleCode] = None,
     PartOf: Option[SimpleCodeWithType] = None,
-    Contacts: Seq[String] = None,
+    Contacts: Seq[String] = Seq.empty,
     Address: Option[Address] = None,
     Endpoints: Seq[String] = Seq.empty,
     DestinationID: Option[String] = None,
 )
 object OrganizationEntry extends RobustPrimitives
-
-@jsonDefaults case class OrganizationEndpoint(
-    Name: String,
-    Identifiers: Seq[SimpleCodeWithType] = Seq.empty,
-    ConnectionType: Option[SimpleCode] = None,
-    Address: Option[String] = None,
-    MIMEType: Option[String] = None,
-    Attributes: Option[OrganizationAttributes] = None,
-)
-object OrganizationEndpoint extends RobustPrimitives
 
 @jsonDefaults case class OrganizationAttributes(
     Transaction: Option[String] = None,
@@ -34,17 +29,30 @@ object OrganizationEndpoint extends RobustPrimitives
 )
 object OrganizationAttributes extends RobustPrimitives
 
+@jsonDefaults case class OrganizationEndpoint(
+    Name: String,
+    Identifiers: Seq[SimpleCodeWithType] = Seq.empty,
+    ConnectionType: Option[SimpleCode] = None,
+    Address: Option[String] = None,
+    MIMEType: Option[String] = None,
+    Attributes: Option[OrganizationAttributes] = None,
+)
+object OrganizationEndpoint extends RobustPrimitives
+
 @jsonDefaults case class OrganizationNameSearch(
     SearchType: Option[String], // exact | partOf
     Value: Option[String],
 )
+object OrganizationNameSearch extends RobustPrimitives
 
 @jsonDefaults case class OrganizationRadiusSearch(
     ZipCode: Option[String],
     Radius: Option[String],
 )
+object OrganizationRadiusSearch extends RobustPrimitives
 
 @jsonDefaults case class OrganizationPaging(
     Count: Option[Int],
     Index: Option[Int],
 )
+object OrganizationPaging extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/OrganizationEntry.scala
@@ -19,6 +19,11 @@ import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
 )
 object OrganizationEntry extends RobustPrimitives
 
+@jsonDefaults case class OrganizationIdentifiers(
+    Identifiers: Seq[Identifier] = Seq.empty
+)
+object OrganizationIdentifiers extends RobustPrimitives
+
 @jsonDefaults case class OrganizationAttributes(
     Transaction: Option[String] = None,
     Actor: Option[SimpleCode] = None,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -103,8 +103,10 @@ object Contact extends RobustPrimitives
   Guarantor: Option[Guarantor] = None,
   Insurances: Seq[Insurance] = Seq.empty,
   Diagnoses: Seq[CodesetWithName] = Seq.empty,
-  PCP: Option[Provider] = None
+  PCP: Option[Provider] = None,
 )
+
+object Patient extends RobustPrimitives
 
 /**
  * Merged Patient has extra "previous identifiers" to indicate retired MRNs
@@ -121,4 +123,17 @@ object Contact extends RobustPrimitives
   PCP: Option[Provider] = None
 )
 
-object Patient extends RobustPrimitives
+object MergedPatient extends RobustPrimitives
+
+/**
+ * PatientSearch datamodel only includes demographics + organizations
+ */
+@jsonDefaults case class PatientSearchPatient(
+  Identifiers: Seq[Identifier] = Seq.empty,
+  Demographics: Option[Demographics] = None,
+  Organization: Option[OrganizationIdentifiers] = None,
+  Notes: Seq[String] = Seq.empty,
+)
+
+object PatientSearchPatient extends RobustPrimitives
+

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/Patient.scala
@@ -131,9 +131,24 @@ object MergedPatient extends RobustPrimitives
 @jsonDefaults case class PatientSearchPatient(
   Identifiers: Seq[Identifier] = Seq.empty,
   Demographics: Option[Demographics] = None,
-  Organization: Option[OrganizationIdentifiers] = None,
   Notes: Seq[String] = Seq.empty,
 )
-
 object PatientSearchPatient extends RobustPrimitives
+
+/**
+ * PatientSearch response only includes identifiers
+ */
+@jsonDefaults case class PatientSearchResponsePatient(Identifiers: Seq[Identifier])
+object PatientSearchResponsePatient extends RobustPrimitives
+
+/**
+ * PatientSearch^LocationQuery returns patient identifiers + organization
+ */
+@jsonDefaults case class LocationQueryPatient(
+  Identifiers: Seq[Identifier] = Seq.empty,
+  Organization: Option[OrganizationEntry] = None,
+)
+
+object LocationQueryPatient extends RobustPrimitives
+
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -169,6 +169,48 @@ object OrderMessage extends RobustPrimitives
 object GroupedOrdersMessage extends RobustPrimitives
 
 /**
+ * Manage organizational directory entries
+ * Meta.DataModel: "Organization"
+ * Meta.EventType: {New, Update}
+ */
+@jsonDefaults case class Organization(
+  Meta: Meta,
+  Directory: String,
+  Organizations: Seq[OrganizationEntry] = Seq.empty,
+)
+object Organization extends RobustPrimitives
+
+/**
+ * Query the organizational directory.
+ * Meta.DataModel: "Organization"
+ * Meta.EventType: Query
+ */
+@jsonDefault case class OrganizationQuery(
+  Meta: Meta,
+  Directory: String,
+  Identifier: Option[Identifier] = None,
+   NameSearch: Option[OrganizationNameSearch] = None,
+   State: Option[String] = None,
+   RadiusSearch: Option[OrganizationRadiusSearch] = None,
+   LastUpdated: Option[DateTime] = None,
+   Index: Option[Int] = None,
+   Limit: Option[Int] = None,
+)
+object OrganizationQuery extends RobustPrimitives
+
+/** Response for organizational directory query
+ * Meta.DataModel: Organization
+ * Meta.EventType: Query
+ */
+@jsonDefault case class OrganizationQueryResponse(
+  Meta: Meta,
+  Directory: String,
+  Organizations: Seq[OrganizationEntry] = Seq.empty,
+  Paging: Option[OrganizationPaging] = None,
+)
+object OrganizationQueryResponse extends RobustPrimitives
+
+/**
  * Used for both query (without the 'PotentialMatches') and holding the response to a patient search query.
  *
  * Meta.DataModel: "PatientSearch",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -222,7 +222,6 @@ object OrganizationQueryResponse extends RobustPrimitives
 @jsonDefaults case class PatientSearchQuery(
   Meta: Meta,
   Patient: Option[PatientSearchPatient] = None,
-  PotentialMatches: Seq[Patient] = Seq.empty
 ) extends RedoxMessage
 
 object PatientSearchQuery extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -249,7 +249,7 @@ object PatientSearchRLSCarequalityResponse extends RobustPrimitives
   PotentialMatches: Seq[Patient] = Seq.empty
 ) extends RedoxMessage
 
-object PatientSearch extends RobustPrimitives
+object PatientSearchResponse extends RobustPrimitives
 
 /**
  *  Used for finding patient identifiers at various organizations in an organizational directory, given
@@ -274,53 +274,6 @@ object LocationQuery extends RobustPrimitives
   Patients: Seq[LocationQueryPatient] = Seq.empty,
 )
 object LocationQueryResponse extends RobustPrimitives
-
-/**
- * Query an organization for patient documents given the patient's Identifier(s)
- * Meta.DataModel: "ClinicalSummary"
- * Meta.EventType: "DocumentQuery"
- */
-@jsonDefaults case class DocumentQuery(
-  Meta: Meta,
-  Patient: Option[clinicalsummary.Patient] = None,
-)
-object DocumentQuery extends RobustPrimitives
-
-/**
- * Response to DocumentQuery includes document Identifiers for the patient
- * Meta.DataModel: "ClinicalSummary"
- * Meta.EventType: "DocumentQuery"
- */
-@jsonDefaults case class DocumentQueryResponse(
-  Meta: Meta,
-  Patient: Option[clinicalsummary.Patient] = None,
-  Documents: Seq[clinicalsummary.Document] = Seq.empty,
-)
-
-object DocumentQueryResponse extends RobustPrimitives
-
-/**
- * Get a single document for a patient from an organization
- * Meta.DataModel: "ClinicalSummary"
- * Meta.EventType: "DocumentGet"
- */
-@jsonDefaults case class DocumentGet(
-  Meta: Meta,
-  Document: Option[clinicalsummary.Document] = None, // Only ID is needed for this query
-)
-object DocumentGet extends RobustPrimitives
-
-/**
- * Response for a DocumentGet request includes the document ID and the XML data
- * Meta.DataModel: "ClinicalSummary"
- * Meta.EventType: "DocumentGet"
- */
-@jsonDefaults case class DocumentGetResponse(
-  Meta: Meta,
-  Document: Option[clinicalsummary.Document] = None, 
-  Data: String,
-)
-object DocumentGetResponse extends RobustPrimitives
 
 /**
  * Meta.DataModel: "PatientAdmin",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -2,6 +2,9 @@ package com.github.vitalsoftware.scalaredox.models
 
 import com.github.vitalsoftware.macros.jsonDefaults
 import com.github.vitalsoftware.util.RobustPrimitives
+import org.joda.time.DateTime
+import com.github.vitalsoftware.util.JsonImplicits.jodaISO8601Format
+import play.api.libs.json.{ Format, Reads, Writes }
 
 import scala.collection.Seq
 
@@ -185,7 +188,7 @@ object Organization extends RobustPrimitives
  * Meta.DataModel: "Organization"
  * Meta.EventType: Query
  */
-@jsonDefault case class OrganizationQuery(
+@jsonDefaults case class OrganizationQuery(
   Meta: Meta,
   Directory: String,
   Identifier: Option[Identifier] = None,
@@ -202,7 +205,7 @@ object OrganizationQuery extends RobustPrimitives
  * Meta.DataModel: Organization
  * Meta.EventType: Query
  */
-@jsonDefault case class OrganizationQueryResponse(
+@jsonDefaults case class OrganizationQueryResponse(
   Meta: Meta,
   Directory: String,
   Organizations: Seq[OrganizationEntry] = Seq.empty,

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -214,18 +214,113 @@ object OrganizationQuery extends RobustPrimitives
 object OrganizationQueryResponse extends RobustPrimitives
 
 /**
- * Used for both query (without the 'PotentialMatches') and holding the response to a patient search query.
+ * Used to search for a patient by demographics
  *
  * Meta.DataModel: "PatientSearch",
- * Meta.EventType: {Query, Response}
+ * Meta.EventType: Query
  */
-@jsonDefaults case class PatientSearch(
+@jsonDefaults case class PatientSearchQuery(
   Meta: Meta,
   Patient: Option[PatientSearchPatient] = None,
   PotentialMatches: Seq[Patient] = Seq.empty
 ) extends RedoxMessage
 
+object PatientSearchQuery extends RobustPrimitives
+
+/** Response from Redox's "Record Locator Service for Carequality" patient search only includes a "Redox Patient ID"
+ * Meta.DataModel: "PatientSearch"
+ * Meta.EventType: Query
+ */
+@jsonDefaults case class PatientSearchRLSCarequalityResponse(
+  Meta: Meta,
+  Patient: Option[PatientSearchPatient]
+)
+object PatientSearchRLSCarequalityResponse extends RobustPrimitives
+
+/**
+ * Response to the above PatientSearch
+ *
+ * Meta.DataModel: "PatientSearch",
+ * Meta.EventType: Response
+ */
+@jsonDefaults case class PatientSearchResponse(
+  Meta: Meta,
+  Patient: Option[Patient] = None,
+  PotentialMatches: Seq[Patient] = Seq.empty
+) extends RedoxMessage
+
 object PatientSearch extends RobustPrimitives
+
+/**
+ *  Used for finding patient identifiers at various organizations in an organizational directory, given
+ *  a universal "redox patient id" in a PatientSearch^LocationQuery request
+ *  Meta.DataModel: "PatientSearch"
+ *  Meta.EventType: "LocationQuery"
+ */
+@jsonDefaults case class LocationQuery(
+  Meta: Meta,
+  Patient: Option[LocationQueryPatient] = None,
+)
+object LocationQuery extends RobustPrimitives
+
+/**
+ * Response class for the above LocationQuery with matching patients + organizational IDs for each organization
+ * in the directory that knows about this patient
+ * Meta.DataModel: "PatientSearch"
+ * Meta.EventType: "LocationQueryResponse"
+ */
+@jsonDefaults case class LocationQueryResponse(
+  Meta: Meta,
+  Patients: Seq[LocationQueryPatient] = Seq.empty,
+)
+object LocationQueryResponse extends RobustPrimitives
+
+/**
+ * Query an organization for patient documents given the patient's Identifier(s)
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentQuery"
+ */
+@jsonDefaults case class DocumentQuery(
+  Meta: Meta,
+  Patient: Option[clinicalsummary.Patient] = None,
+)
+object DocumentQuery extends RobustPrimitives
+
+/**
+ * Response to DocumentQuery includes document Identifiers for the patient
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentQuery"
+ */
+@jsonDefaults case class DocumentQueryResponse(
+  Meta: Meta,
+  Patient: Option[clinicalsummary.Patient] = None,
+  Documents: Seq[clinicalsummary.Document] = Seq.empty,
+)
+
+object DocumentQueryResponse extends RobustPrimitives
+
+/**
+ * Get a single document for a patient from an organization
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentGet"
+ */
+@jsonDefaults case class DocumentGet(
+  Meta: Meta,
+  Document: Option[clinicalsummary.Document] = None, // Only ID is needed for this query
+)
+object DocumentGet extends RobustPrimitives
+
+/**
+ * Response for a DocumentGet request includes the document ID and the XML data
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentGet"
+ */
+@jsonDefaults case class DocumentGetResponse(
+  Meta: Meta,
+  Document: Option[clinicalsummary.Document] = None, 
+  Data: String,
+)
+object DocumentGetResponse extends RobustPrimitives
 
 /**
  * Meta.DataModel: "PatientAdmin",

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -221,7 +221,7 @@ object OrganizationQueryResponse extends RobustPrimitives
  */
 @jsonDefaults case class PatientSearch(
   Meta: Meta,
-  Patient: Option[Patient] = None,
+  Patient: Option[PatientSearchPatient] = None,
   PotentialMatches: Seq[Patient] = Seq.empty
 ) extends RedoxMessage
 

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/RedoxMessage.scala
@@ -237,18 +237,18 @@ object PatientSearchQuery extends RobustPrimitives
 object PatientSearchRLSCarequalityResponse extends RobustPrimitives
 
 /**
- * Response to the above PatientSearch
+ * Response to the above PatientSearch. Can be used as the query in some cases too
  *
  * Meta.DataModel: "PatientSearch",
- * Meta.EventType: Response
+ * Meta.EventType: Response|Query
  */
-@jsonDefaults case class PatientSearchResponse(
+@jsonDefaults case class PatientSearch(
   Meta: Meta,
   Patient: Option[Patient] = None,
   PotentialMatches: Seq[Patient] = Seq.empty
 ) extends RedoxMessage
 
-object PatientSearchResponse extends RobustPrimitives
+object PatientSearch extends RobustPrimitives
 
 /**
  *  Used for finding patient identifiers at various organizations in an organizational directory, given

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.6.1-RC5"
+version in ThisBuild := "10.7.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.6.1-RC4"
+version in ThisBuild := "10.6.1-RC5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.6.0"
+version in ThisBuild := "10.6.1-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.6.1-RC2"
+version in ThisBuild := "10.6.1-RC4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.6.1-RC1"
+version in ThisBuild := "10.6.1-RC2"


### PR DESCRIPTION
The [organization datamodel](https://developer.redoxengine.com/data-models/Organization.html) is now available for interacting with organizational directories (like Carequality).

Also added event types for various Carequality operations:
* PatientSearch^LocationQuery
* ClinicalSummary^DocumentQuery
* ClinicalSummary^DocumentGet
