### PR TITLE
DocumentGet and DocumentQuery models

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/DocumentGet.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/DocumentGet.scala
@@ -1,0 +1,28 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary
+
+import com.github.vitalsoftware.scalaredox.models.Meta
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ * Get a single document for a patient from an organization
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentGet"
+ */
+@jsonDefaults case class DocumentGet(
+  Meta: Meta,
+  Document: Option[Document] = None, // Only ID is needed for this query
+)
+object DocumentGet extends RobustPrimitives
+
+/**
+ * Response for a DocumentGet request includes the document ID and the XML data
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentGet"
+ */
+@jsonDefaults case class DocumentGetResponse(
+  Meta: Meta,
+  Document: Option[Document] = None, 
+  Data: String,
+)
+object DocumentGetResponse extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/DocumentQuery.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/DocumentQuery.scala
@@ -1,0 +1,29 @@
+package com.github.vitalsoftware.scalaredox.models.clinicalsummary
+
+import com.github.vitalsoftware.scalaredox.models.Meta
+import com.github.vitalsoftware.macros.jsonDefaults
+import com.github.vitalsoftware.util.RobustPrimitives
+
+/**
+ * Query an organization for patient documents given the patient's Identifier(s)
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentQuery"
+ */
+@jsonDefaults case class DocumentQuery(
+  Meta: Meta,
+  Patient: Option[Patient] = None,
+)
+object DocumentQuery extends RobustPrimitives
+
+/**
+ * Response to DocumentQuery includes document Identifiers for the patient
+ * Meta.DataModel: "ClinicalSummary"
+ * Meta.EventType: "DocumentQuery"
+ */
+@jsonDefaults case class DocumentQueryResponse(
+  Meta: Meta,
+  Patient: Option[Patient] = None,
+  Documents: Seq[Document] = Seq.empty,
+)
+
+object DocumentQueryResponse extends RobustPrimitives


### PR DESCRIPTION
These models support querying for documents via Carequality.

DocumentQuery is used to get a list of available documents for a specific patient from another health system.
DocumentGet can be used to download the contents of a specific document given its ID from the DocumentQuery response.