### PR TITLE
Remove some vulnerabilities via version upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,17 +15,18 @@ resolvers ++= Seq(
   "Atlassian Releases" at "https://maven.atlassian.com/public/",
 )
 
-val playJsonVersion = "2.7.3"
-val playVersion = "2.7.3"
+val playJsonVersion = "2.8.0"
+val playLogbackVersion = "2.8.12"
+val playVersion = "2.8.9"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % playJsonVersion,
   "ai.x" %% "play-json-extensions" % "0.42.0",
-  "com.typesafe.play" %% "play-logback" % playJsonVersion,
+  "com.typesafe.play" %% "play-logback" % playLogbackVersion,
   "com.typesafe.play" %% "play-json-joda" % playJsonVersion,
   "com.typesafe.play" %% "play-ahc-ws" % playVersion,
   "com.typesafe.play" %% "play-ws-standalone-json" % "1.1.2",
-  "com.typesafe.akka" %% "akka-http" % "10.1.8",
+  "com.typesafe.akka" %% "akka-http" % "10.1.15",
   "com.github.vital-software" %% "json-annotation" % "0.6.0",
   "com.github.nscala-time" %% "nscala-time" % "2.14.0",
   "com.typesafe.play" %% "play-specs2" % playVersion % Test,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.7.0"
+version in ThisBuild := "10.8.0"


### PR DESCRIPTION
## Purpose
Synk reported a 0 critical, 49 high and 5 medium 1 low vulnerabilities associated with mdcollab/scala-redox:build.sbt

## Approach
Upgrade library versions to remove vulnerabilities, if a such version is available for a given library.

## Testing
Published and tested an RC jar to test if patient/provider app works and if C-CDA import works.