### PR TITLE
fix: Separate VisitPush VisitInfo & related fields

### DIFF
--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasVisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/HasVisitInfo.scala
@@ -7,3 +7,7 @@ trait HasVisit {
 trait HasVisitInfo extends HasVisit {
   def Visit: Option[VisitInfo]
 }
+
+trait HasVisitPushVisitInfo extends HasVisit {
+  def Visit: Option[VisitPushVisitInfo]
+}

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/VisitInfo.scala
@@ -128,3 +128,25 @@ object VisitInfo extends RobustPrimitives
 ) extends VisitLike
 
 object BasicVisitInfo extends RobustPrimitives
+
+// Note: Presently used only by VisitPush
+/**
+ * @param StartDateTime        The start date/time of the visit. ISO 8601 Format
+ * @param EndDateTime          The end date/time of the visit. ISO 8601 Format
+ * @param Reason               The reason for visit. The Reason for Visit is rarely found in the header. Instead, look to the ReasonForVisitText and related fields.
+ * @param VisitNumber          ID for the patient visit/encounter.
+ * @param Type                 Type of the visit (office visit, hospital etc.)
+ * @param Location             The location of the visit.
+ * @param DischargeDisposition Discharge disposition pf the visit.
+ */
+@jsonDefaults case class VisitPushVisitInfo(
+  StartDateTime: Option[DateTime] = None,
+  EndDateTime: Option[String] = None,
+  Reason: Option[String] = None,
+  VisitNumber: Option[String] = None,
+  Type: BasicCode = BasicCode(),
+  Location: Option[CareLocation] = None, //*
+  DischargeDisposition: BasicCode = BasicCode(),
+) extends VisitLike
+
+object VisitPushVisitInfo extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Document.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Document.scala
@@ -1,7 +1,7 @@
 package com.github.vitalsoftware.scalaredox.models.clinicalsummary
 
 import com.github.vitalsoftware.macros.jsonDefaults
-import com.github.vitalsoftware.scalaredox.models.{ BasicCode, DocumentExtension, HasVisitInfo, Provider, VisitInfo }
+import com.github.vitalsoftware.scalaredox.models.{BasicCode, DocumentExtension, HasVisitInfo, HasVisitPushVisitInfo, Provider, VisitInfo, VisitPushVisitInfo}
 import com.github.vitalsoftware.util.RobustPrimitives
 import org.joda.time.DateTime
 import play.api.libs.json.JodaWrites._
@@ -32,3 +32,29 @@ import play.api.libs.json.JodaReads._
 ) extends HasVisitInfo
 
 object Document extends RobustPrimitives
+
+/**
+ * About a clinical summary document
+ *
+ * @param ID Your application's ID for the document
+ * @param Author Provider responsible for this document
+ * @param Visit If the document is tied to a visit
+ * @param Locale The language of the document.
+ * @param Title The title of the document.
+ * @param DateTime The creation/publishing date/time of the document.
+ * @param Type The type of document (CCD, progress note, etc.)
+ * @param TypeCode A code describing the type of document.
+ */
+@jsonDefaults case class VisitPushDocument(
+  Author: Option[Provider] = None,
+  ID: Option[String] = None,
+  Locale: Option[String] = None,
+  Title: Option[String] = None,
+  DateTime: Option[DateTime] = None,
+  Type: Option[String] = None,
+  TypeCode: Option[BasicCode] = None,
+  Visit: Option[VisitPushVisitInfo] = None,
+  Extensions: Option[DocumentExtension] = None,
+) extends HasVisitPushVisitInfo
+
+object VisitPushDocument extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Header.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/Header.scala
@@ -24,3 +24,22 @@ import play.api.libs.json.JodaReads._
 ) extends HasClinicalSummaryPatient
 
 object Header extends RobustPrimitives
+
+/**
+ * Information about the clinical summary's patient and where the summary came from
+ *
+ * @param DirectAddressFrom The sender's Direct address, if one or both sides are using Direct messaging.
+ * @param DirectAddressTo The recipient's Direct address, if one or both sides are using Direct messaging.
+ * @param Document An object containing metadata about the document being pushed to the destination.
+ * @param Patient Patient
+ * @param PCP Provider
+ */
+@jsonDefaults case class VisitPushHeader(
+  DirectAddressFrom: Option[String] = None,
+  DirectAddressTo: Option[String] = None,
+  Document: VisitPushDocument,
+  Patient: Patient,
+  PCP: Option[Provider] = None,
+) extends HasClinicalSummaryPatient
+
+object VisitPushHeader extends RobustPrimitives

--- a/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
+++ b/src/main/scala/com/github/vitalsoftware/scalaredox/models/clinicalsummary/VisitPush.scala
@@ -44,7 +44,7 @@ import scala.collection.Seq
  */
 case class VisitPush(
   Meta: Meta,
-  Header: Header,
+  Header: VisitPushHeader,
   AdvanceDirectives: Seq[AdvanceDirective] = Seq.empty,
   Allergies: Seq[Allergy] = Seq.empty,
   Encounters: Seq[Encounter] = Seq.empty,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "10.9.1"
+version in ThisBuild := "10.10.1"


### PR DESCRIPTION
### What
Separates VisitPush VisitInfo & related fields

### Why
The `VisitInfo` doesn't match the one for VisitPush in Redox API Documentation. 